### PR TITLE
Fix for psycopg2 on gateway

### DIFF
--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -14,4 +14,4 @@ requests
 flask_sqlalchemy
 flask_migrate
 flask_testing
-psycopg2
+psycopg2-binary


### PR DESCRIPTION
Replaced the `psycopg2` package with `psycopg2-binary` in the gateway/requirements.txt file.
> Fixes #343 
