### PR TITLE
Ordered requirements to install grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ PyGrid is a peer-to-peer network of data owners and data scientists who can coll
 ## How to install
 
 #### PyGrid library
-Install requirements and make PyGrid library importable in python:
+Make PyGrid library importable in python:
 ```
-$ pip install -r requirements.txt
-$ python setup.py install
+$ pip install .
 ```
 
 ### Common Installation Issues:


### PR DESCRIPTION
Changed `python setup.py install` for `pip install .` to install requirements in order on grid importable library installation. 