### PR TITLE
Edit docs to serve it remotely 

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,22 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+   version: 3.7
+   install:
+      - requirements: dev-requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 sphinx
+sphinx-autoapi
 rtcat_sphinx_theme
 sphinxcontrib-napoleon

--- a/docs/source/api/grid/auth/authentication/index.rst
+++ b/docs/source/api/grid/auth/authentication/index.rst
@@ -1,0 +1,30 @@
+:mod:`grid.auth.authentication`
+===============================
+
+.. py:module:: grid.auth.authentication
+
+
+Module Contents
+---------------
+
+.. py:class:: BaseAuthentication(filename)
+
+   Bases: :class:`abc.ABC`
+
+   BaseAuthentication abstract class defines generic methods used by all types of authentications defined in this module.
+
+   .. method:: parse(self)
+      :abstractmethod:
+
+
+      Read, parse and load credential files.
+
+
+   .. method:: json(self)
+      :abstractmethod:
+
+
+      Convert credential instances into a JSON structure.
+
+
+

--- a/docs/source/api/grid/auth/config/index.rst
+++ b/docs/source/api/grid/auth/config/index.rst
@@ -1,0 +1,44 @@
+:mod:`grid.auth.config`
+=======================
+
+.. py:module:: grid.auth.config
+
+
+Module Contents
+---------------
+
+.. function:: register_new_credentials(path: str) -> UserAuthentication
+
+   Create a new credential if not found any credential file during load_credentials function.
+
+   :param path: File path.
+   :type path: str
+
+   :returns: New credential instance.
+   :rtype: user (UserAuthentication)
+
+
+.. function:: read_authentication_configs(directory=None, folder=None) -> list
+
+   Search for a path and folder used to store user credentials
+
+   :param directory: System path (can usually be /home/<user>).
+   :type directory: str
+   :param folder: folder name used to store PyGrid credentials.
+   :type folder: str
+
+   :returns: List of credentials instances.
+   :rtype: List
+
+
+.. function:: search_credential(user: str)
+
+   Search for a specific credential instance.
+
+   :param user: Key used to identify the credential.
+   :type user: str
+
+   :returns: Credential's instance.
+   :rtype: BaseAuthentication
+
+

--- a/docs/source/api/grid/auth/index.rst
+++ b/docs/source/api/grid/auth/index.rst
@@ -1,0 +1,103 @@
+:mod:`grid.auth`
+================
+
+.. py:module:: grid.auth
+
+
+Submodules
+----------
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
+
+   authentication/index.rst
+   config/index.rst
+   user_auth/index.rst
+
+
+Package Contents
+----------------
+
+.. py:class:: UserAuthentication(username, password)
+
+   Bases: :class:`grid.auth.authentication.BaseAuthentication`
+
+   .. attribute:: FILENAME
+      :annotation: = auth.user
+
+      
+
+   .. attribute:: USERNAME_FIELD
+      :annotation: = username
+
+      
+
+   .. attribute:: PASSWORD_FIELD
+      :annotation: = password
+
+      
+
+   .. method:: parse(path)
+      :staticmethod:
+
+
+      Static method used to create new user authentication instances parsing a json file.
+
+      :param path: json file path.
+      :type path: str
+
+      :returns: List of user authentication objects.
+      :rtype: List
+
+
+   .. method:: json(self)
+
+
+      Convert user instances into a JSON/Dictionary structure.
+
+
+
+.. data:: BASE_DIR
+   
+
+   
+
+.. data:: BASE_FOLDER
+   :annotation: = .openmined
+
+   
+
+.. data:: AUTH_MODELS
+   
+
+   
+
+.. data:: auth_credentials
+   :annotation: = []
+
+   
+
+.. function:: read_authentication_configs(directory=None, folder=None) -> list
+
+   Search for a path and folder used to store user credentials
+
+   :param directory: System path (can usually be /home/<user>).
+   :type directory: str
+   :param folder: folder name used to store PyGrid credentials.
+   :type folder: str
+
+   :returns: List of credentials instances.
+   :rtype: List
+
+
+.. function:: search_credential(user: str)
+
+   Search for a specific credential instance.
+
+   :param user: Key used to identify the credential.
+   :type user: str
+
+   :returns: Credential's instance.
+   :rtype: BaseAuthentication
+
+

--- a/docs/source/api/grid/auth/user_auth/index.rst
+++ b/docs/source/api/grid/auth/user_auth/index.rst
@@ -1,0 +1,48 @@
+:mod:`grid.auth.user_auth`
+==========================
+
+.. py:module:: grid.auth.user_auth
+
+
+Module Contents
+---------------
+
+.. py:class:: UserAuthentication(username, password)
+
+   Bases: :class:`grid.auth.authentication.BaseAuthentication`
+
+   .. attribute:: FILENAME
+      :annotation: = auth.user
+
+      
+
+   .. attribute:: USERNAME_FIELD
+      :annotation: = username
+
+      
+
+   .. attribute:: PASSWORD_FIELD
+      :annotation: = password
+
+      
+
+   .. method:: parse(path)
+      :staticmethod:
+
+
+      Static method used to create new user authentication instances parsing a json file.
+
+      :param path: json file path.
+      :type path: str
+
+      :returns: List of user authentication objects.
+      :rtype: List
+
+
+   .. method:: json(self)
+
+
+      Convert user instances into a JSON/Dictionary structure.
+
+
+

--- a/docs/source/api/grid/deploy/base_deployment/index.rst
+++ b/docs/source/api/grid/deploy/base_deployment/index.rst
@@ -1,0 +1,58 @@
+:mod:`grid.deploy.base_deployment`
+==================================
+
+.. py:module:: grid.deploy.base_deployment
+
+
+Module Contents
+---------------
+
+.. py:class:: BaseDeployment(env_vars, verbose: bool = True)
+
+   Bases: :class:`abc.ABC`
+
+   Abstract Class used to instantiate generic attributes for other deployment classes.
+
+   .. method:: deploy(self)
+      :abstractmethod:
+
+
+      Method used to deploy component.
+
+
+   .. method:: _check_dependency(self, lib='git', check='usage:', error_msg='Error: please install git.', verbose=False)
+
+
+      This method checks if the environment has a specific dependency.
+      :param dependency_lib: Libs that will be verified.
+      :param check: Specific string to check if app was installed.
+      :param error_msg: If not installed, raise an Exception with this.
+      :param verbose: Used to define level of verbosity.
+
+      :raises RuntimeError: If not installed, raise a RuntimeError Exception.
+
+
+   .. method:: _execute(self, cmd)
+
+
+      Execute a specific bash command and return the result.
+      :param cmd: Specific bash command.
+
+      :raises subprocess_exception: Raises an specific subprocess exception
+
+
+   .. method:: _run_commands_in(self, commands, logs, tmp_dir='tmp', cleanup=True, verbose=False)
+
+
+      Run sequentially all commands and logs stored in our list of commands/logs.
+      :param commands: List of commands.
+      :param logs: List of logs.
+      :param tmp_dir: Directory used execute these commands.
+      :param cleanup: Flag to choose if tmp_dir will be maintained.
+      :param verbose: Used to define level of verbosity.
+
+      :returns: Output message for each command.
+      :rtype: outputs
+
+
+

--- a/docs/source/api/grid/deploy/heroku_gateway/index.rst
+++ b/docs/source/api/grid/deploy/heroku_gateway/index.rst
@@ -1,0 +1,34 @@
+:mod:`grid.deploy.heroku_gateway`
+=================================
+
+.. py:module:: grid.deploy.heroku_gateway
+
+
+Module Contents
+---------------
+
+.. py:class:: HerokuGatewayDeployment(app_name: str, verbose=True, check_deps=True, dev_user: str = 'OpenMined', branch: set = 'dev', env_vars={})
+
+   Bases: :class:`grid.deploy.BaseDeployment`
+
+   An abstraction of heroku grid gateway deployment process, the purpose of this class is set all configuration needed to deploy grid gateway application in heroku platform.
+
+   .. method:: deploy(self)
+
+
+      Method to deploy Grid Gateway app on heroku platform.
+
+
+   .. method:: __run_heroku_commands(self)
+
+
+      Add a set of commands/logs used to deploy grid gateway app on heroku platform.
+
+
+   .. method:: __check_heroku_dependencies(self)
+
+
+      Check specific dependencies to perform grid gateway deploy on heroku platform.
+
+
+

--- a/docs/source/api/grid/deploy/heroku_node/index.rst
+++ b/docs/source/api/grid/deploy/heroku_node/index.rst
@@ -1,0 +1,34 @@
+:mod:`grid.deploy.heroku_node`
+==============================
+
+.. py:module:: grid.deploy.heroku_node
+
+
+Module Contents
+---------------
+
+.. py:class:: HerokuNodeDeployment(grid_name: str, verbose=True, check_deps=True, app_type: str = 'websocket', dev_user: str = 'OpenMined', branch: set = 'dev', env_vars={})
+
+   Bases: :class:`grid.deploy.BaseDeployment`
+
+   An abstraction of heroku grid node deployment process, the purpose of this class is set all configuration needed to deploy grid node application in heroku platform.
+
+   .. method:: deploy(self)
+
+
+      Method to deploy Grid Node app on heroku platform.
+
+
+   .. method:: __run_heroku_commands(self)
+
+
+      Add a set of commands/logs used to deploy grid node app on heroku platform.
+
+
+   .. method:: __check_heroku_dependencies(self)
+
+
+      Check specific dependencies to perform grid node deploy on heroku platform.
+
+
+

--- a/docs/source/api/grid/deploy/index.rst
+++ b/docs/source/api/grid/deploy/index.rst
@@ -1,0 +1,94 @@
+:mod:`grid.deploy`
+==================
+
+.. py:module:: grid.deploy
+
+
+Submodules
+----------
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
+
+   base_deployment/index.rst
+   heroku_gateway/index.rst
+   heroku_node/index.rst
+
+
+Package Contents
+----------------
+
+.. py:class:: BaseDeployment(env_vars, verbose: bool = True)
+
+   Bases: :class:`abc.ABC`
+
+   Abstract Class used to instantiate generic attributes for other deployment classes.
+
+   .. method:: deploy(self)
+      :abstractmethod:
+
+
+      Method used to deploy component.
+
+
+   .. method:: _check_dependency(self, lib='git', check='usage:', error_msg='Error: please install git.', verbose=False)
+
+
+      This method checks if the environment has a specific dependency.
+      :param dependency_lib: Libs that will be verified.
+      :param check: Specific string to check if app was installed.
+      :param error_msg: If not installed, raise an Exception with this.
+      :param verbose: Used to define level of verbosity.
+
+      :raises RuntimeError: If not installed, raise a RuntimeError Exception.
+
+
+   .. method:: _execute(self, cmd)
+
+
+      Execute a specific bash command and return the result.
+      :param cmd: Specific bash command.
+
+      :raises subprocess_exception: Raises an specific subprocess exception
+
+
+   .. method:: _run_commands_in(self, commands, logs, tmp_dir='tmp', cleanup=True, verbose=False)
+
+
+      Run sequentially all commands and logs stored in our list of commands/logs.
+      :param commands: List of commands.
+      :param logs: List of logs.
+      :param tmp_dir: Directory used execute these commands.
+      :param cleanup: Flag to choose if tmp_dir will be maintained.
+      :param verbose: Used to define level of verbosity.
+
+      :returns: Output message for each command.
+      :rtype: outputs
+
+
+
+.. py:class:: HerokuGatewayDeployment(app_name: str, verbose=True, check_deps=True, dev_user: str = 'OpenMined', branch: set = 'dev', env_vars={})
+
+   Bases: :class:`grid.deploy.BaseDeployment`
+
+   An abstraction of heroku grid gateway deployment process, the purpose of this class is set all configuration needed to deploy grid gateway application in heroku platform.
+
+   .. method:: deploy(self)
+
+
+      Method to deploy Grid Gateway app on heroku platform.
+
+
+   .. method:: __run_heroku_commands(self)
+
+
+      Add a set of commands/logs used to deploy grid gateway app on heroku platform.
+
+
+   .. method:: __check_heroku_dependencies(self)
+
+
+      Check specific dependencies to perform grid gateway deploy on heroku platform.
+
+
+

--- a/docs/source/api/grid/grid_codes/index.rst
+++ b/docs/source/api/grid/grid_codes/index.rst
@@ -1,0 +1,99 @@
+:mod:`grid.grid_codes`
+======================
+
+.. py:module:: grid.grid_codes
+
+
+Module Contents
+---------------
+
+.. py:class:: REQUEST_MSG
+
+   Bases: :class:`object`
+
+   .. attribute:: TYPE_FIELD
+      :annotation: = type
+
+      
+
+   .. attribute:: GET_ID
+      :annotation: = get-id
+
+      
+
+   .. attribute:: CONNECT_NODE
+      :annotation: = connect-node
+
+      
+
+   .. attribute:: AUTHENTICATE
+      :annotation: = authentication
+
+      
+
+   .. attribute:: HOST_MODEL
+      :annotation: = host-model
+
+      
+
+   .. attribute:: RUN_INFERENCE
+      :annotation: = run-inference
+
+      
+
+   .. attribute:: LIST_MODELS
+      :annotation: = list-models
+
+      
+
+   .. attribute:: DELETE_MODEL
+      :annotation: = delete-model
+
+      
+
+   .. attribute:: DOWNLOAD_MODEL
+      :annotation: = download-model
+
+      
+
+   .. attribute:: SYFT_COMMAND
+      :annotation: = syft-command
+
+      
+
+   .. attribute:: PING
+      :annotation: = socket-ping
+
+      
+
+
+.. py:class:: RESPONSE_MSG
+
+   Bases: :class:`object`
+
+   .. attribute:: NODE_ID
+      :annotation: = id
+
+      
+
+   .. attribute:: INFERENCE_RESULT
+      :annotation: = prediction
+
+      
+
+   .. attribute:: MODELS
+      :annotation: = models
+
+      
+
+   .. attribute:: ERROR
+      :annotation: = error
+
+      
+
+   .. attribute:: SUCCESS
+      :annotation: = success
+
+      
+
+

--- a/docs/source/api/grid/grid_network/index.rst
+++ b/docs/source/api/grid/grid_network/index.rst
@@ -1,0 +1,106 @@
+:mod:`grid.grid_network`
+========================
+
+.. py:module:: grid.grid_network
+
+
+Module Contents
+---------------
+
+.. data:: SMPC_HOST_CHUNK
+   :annotation: = 4
+
+   
+
+.. py:class:: GridNetwork(gateway_url)
+
+   Bases: :class:`object`
+
+   The purpose of the Grid Network class is to control the entire communication flow by abstracting operational steps.
+
+   .. attribute:: - gateway_url
+
+      network address to which you want to connect.
+
+   .. attribute:: - connected_grid_nodes
+
+      Grid nodes that are connected to the application.
+
+   .. method:: search(self, *query)
+
+
+      Search a set of tags across the grid network.
+
+      :param query: A set of dataset tags.
+
+      :returns: matrix of tensor pointers.
+      :rtype: tensor_matrix
+
+
+   .. method:: serve_encrypted_model(self, model)
+
+
+      This method wiil choose some grid nodes at grid network to host an encrypted model.
+
+      :param model: Model to be hosted.
+
+      Raise:
+          RuntimeError : If grid network doesn't have enough workers to host an encrypted model.
+
+
+   .. method:: serve_model(self, model, model_id, allow_remote_inference: bool = False, allow_download: bool = False)
+
+
+      This method will choose one of grid nodes registered in the grid network to host a plain text model.
+      :param model: Model to be hosted.
+      :param model_id: Model's ID.
+      :param allow_remote_inference: Allow workers to run inference in this model.
+      :param allow_download: Allow workers to copy the model and run it locally.
+
+
+   .. method:: run_encrypted_inference(self, model_id, data, copy=True)
+
+
+      Search for an encrypted model and perform inference.
+
+      :param model_id: Model's ID.
+      :param data: Dataset to be shared/inferred.
+      :param copy: Boolean flag to perform encrypted inference without lose plan.
+
+      :returns: Inference's result.
+      :rtype: Tensor
+
+
+   .. method:: run_remote_inference(self, model_id, data)
+
+
+      This method will search for a specific model registered on grid network, if found,
+      It will run inference.
+      :param model_id: Model's ID.
+      :param dataset: Data used to run inference.
+
+      :returns: Inference's result.
+      :rtype: Tensor
+
+
+   .. method:: query_model(self, model_id)
+
+
+      This method will search for a specific model registered on grid network, if found,
+      It will return all grid nodes that contains the desired model.
+      :param model_id: Model's ID.
+      :param data: Data used to run inference.
+
+      :returns: List of workers that contains the desired model.
+      :rtype: workers
+
+
+   .. method:: __connect_with_node(self, node_id, node_url)
+
+
+
+   .. method:: disconnect_nodes(self)
+
+
+
+

--- a/docs/source/api/grid/index.rst
+++ b/docs/source/api/grid/index.rst
@@ -1,0 +1,39 @@
+:mod:`grid`
+===========
+
+.. py:module:: grid
+
+
+Subpackages
+-----------
+.. toctree::
+   :titlesonly:
+   :maxdepth: 3
+
+   auth/index.rst
+   deploy/index.rst
+   workers/index.rst
+
+
+Submodules
+----------
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
+
+   grid_codes/index.rst
+   grid_network/index.rst
+   utils/index.rst
+   websocket_client/index.rst
+
+
+Package Contents
+----------------
+
+.. function:: connect_all_nodes(nodes: list)
+
+   Connect all nodes to each other.
+
+   :param nodes: A tuple of grid clients.
+
+

--- a/docs/source/api/grid/utils/index.rst
+++ b/docs/source/api/grid/utils/index.rst
@@ -1,0 +1,32 @@
+:mod:`grid.utils`
+=================
+
+.. py:module:: grid.utils
+
+.. autoapi-nested-parse::
+
+   Utility functions.
+
+
+
+Module Contents
+---------------
+
+.. function:: execute_command(command: str) -> str
+
+   Executes the given command using the os inherent shell.
+
+   :param command: The command to execute
+   :type command: str
+
+   :returns: command's result
+   :rtype: result (str)
+
+
+.. function:: connect_all_nodes(nodes: list)
+
+   Connect all nodes to each other.
+
+   :param nodes: A tuple of grid clients.
+
+

--- a/docs/source/api/grid/websocket_client/index.rst
+++ b/docs/source/api/grid/websocket_client/index.rst
@@ -1,0 +1,241 @@
+:mod:`grid.websocket_client`
+============================
+
+.. py:module:: grid.websocket_client
+
+
+Module Contents
+---------------
+
+.. data:: MODEL_LIMIT_SIZE
+   
+
+   
+
+.. py:class:: WebsocketGridClient(hook, address, id: Union[int, str] = 0, auth: dict = None, is_client_worker: bool = False, log_msgs: bool = False, verbose: bool = False, chunk_size: int = MODEL_LIMIT_SIZE)
+
+   Bases: :class:`syft.WebsocketClientWorker`, :class:`syft.federated.federated_client.FederatedClient`
+
+   Websocket Grid Client.
+
+   .. method:: url(self)
+      :property:
+
+
+      Get Node URL Address.
+
+      :returns: Node's address.
+      :rtype: address (str)
+
+
+   .. method:: _update_node_reference(self, new_id: str)
+
+
+      Update worker references changing node id references at hook structure.
+
+      :param new_id: New worker ID.
+      :type new_id: str
+
+
+   .. method:: parse_address(self, address: str)
+
+
+      Parse Address string to define secure flag and split into host and port.
+
+      :param address: Adress of remote worker.
+      :type address: str
+
+
+   .. method:: get_node_id(self)
+
+
+      Get Node ID from remote node worker
+
+      :returns: node id used by remote worker.
+      :rtype: node_id (str)
+
+
+   .. method:: connect_nodes(self, node)
+
+
+      Connect two remote workers between each other.
+      If this node is authenticated, use the same credentials to authenticate the candidate node.
+
+      :param node: Node that will be connected with this remote worker.
+      :type node: WebsocketGridClient
+
+      :returns: node response.
+      :rtype: node_response (dict)
+
+
+   .. method:: authenticate(self, user: Union[str, dict])
+
+
+      Perform Authentication Process using credentials grid credentials.
+      Grid credentials can be loaded calling the function gr.load_credentials().
+
+      :param user: String containing the username of a loaded credential or a credential's dict.
+
+      :raises RuntimeError: If authentication process fail.
+
+
+   .. method:: _forward_json_to_websocket_server_worker(self, message: dict)
+
+
+      Prepare/send a JSON message to a remote grid node and receive the response.
+
+      :param message: message payload.
+      :type message: dict
+
+      :returns: response payload.
+      :rtype: node_response (dict)
+
+
+   .. method:: _forward_to_websocket_server_worker(self, message: bin)
+
+
+      Prepare/send a binary message to a remote grid node and receive the response.
+      :param message: message payload.
+      :type message: bytes
+
+      :returns: response payload.
+      :rtype: node_response (bytes)
+
+
+   .. method:: serve_model(self, model, model_id: str = None, allow_download: bool = False, allow_remote_inference: bool = False)
+
+
+      Hosts the model and optionally serve it using a Socket / Rest API.
+
+      :param model: A jit model or Syft Plan.
+      :param model_id: An integer or string representing the model id used to retrieve the model
+                       later on using the Rest API. If this is not provided and the model is a Plan
+                       we use model.id, if the model is a jit model we raise an exception.
+      :type model_id: str
+      :param allow_download: If other workers should be able to fetch a copy of this model to run it locally set this to True.
+      :type allow_download: bool
+      :param allow_remote_inference: If other workers should be able to run inference using this model through a Rest API interface set this True.
+      :type allow_remote_inference: bool
+
+      :returns: True if model was served sucessfully, raises a RunTimeError otherwise.
+      :rtype: result (bool)
+
+      :raises ValueError: if model_id is not provided and model is a jit model (aka does not have an id attribute).
+      :raises RunTimeError: if there was a problem during model serving.
+
+
+   .. method:: run_remote_inference(self, model_id, data)
+
+
+      Run a dataset inference using a remote model.
+
+      :param model_id: Model ID.
+      :type model_id: str
+      :param data: dataset to be inferred.
+      :type data: Tensor
+
+      :returns: Inference result
+      :rtype: inference (Tensor)
+
+      :raises RuntimeError: If an unexpected behavior happen, It will forward the error message.
+
+
+   .. method:: _return_bool_result(self, result, return_key=None)
+
+
+
+   .. method:: _send_http_request(self, route, data, request, N: int = 10, unhexlify: bool = True, return_response_text: bool = True)
+
+
+      Helper function for sending http request to talk to app.
+
+      :param route: App route.
+      :type route: str
+      :param data: Data to be sent in the request.
+      :type data: str
+      :param request: Request type (GET, POST, PUT, ...).
+      :type request: str
+      :param N: Number of tries in case of fail. Default is 10.
+      :type N: int
+      :param unhexlify: A boolean indicating if we should try to run unhexlify on the response or not.
+      :type unhexlify: bool
+      :param return_response_text: If True return response.text, return raw response otherwise.
+      :type return_response_text: bool
+
+      :returns: If return_response_text is True return response.text, return raw response otherwise.
+      :rtype: response (bool)
+
+
+   .. method:: _send_streaming_post(self, route: str, data: dict = None)
+
+
+      Used to send large models / datasets using stream channel.
+
+      :param route: Service endpoint
+      :type route: str
+      :param data: dict with tensors / models to be uploaded.
+      :type data: dict
+
+      :returns: response from server
+      :rtype: response (str)
+
+
+   .. method:: _send_get(self, route, data=None, **kwargs)
+
+
+
+   .. method:: models(self)
+      :property:
+
+
+      Get models stored at remote grid node.
+
+      :returns: List of models stored in this grid node.
+      :rtype: models (List)
+
+
+   .. method:: delete_model(self, model_id: str)
+
+
+      Delete a model previously registered.
+
+      :param model_id: ID of the model that will be deleted.
+      :type model_id: String
+
+      :returns: If succeeded, return True.
+      :rtype: result (bool)
+
+
+   .. method:: download_model(self, model_id: str)
+
+
+      Download a model to run it locally.
+
+      :param model_id: ID of the model that will be downloaded.
+      :type model_id: str
+
+      :returns: Model to be downloaded.
+      :rtype: model
+
+      :raises RuntimeError: If an unexpected behavior happen, It will forward the error message.
+
+
+   .. method:: serve_encrypted_model(self, encrypted_model: sy.messaging.plan.Plan)
+
+
+      Serve a model in a encrypted fashion using SMPC.
+
+      A wrapper for sending the model. The worker is responsible for sharing the model using SMPC.
+
+      :param encrypted_model: A pĺan already shared with workers using SMPC.
+      :type encrypted_model: syft.Plan
+
+      :returns: True if model was served successfully, raises a RunTimeError otherwise.
+      :rtype: result (bool)
+
+
+   .. method:: __str__(self)
+
+
+
+

--- a/docs/source/api/grid/workers/index.rst
+++ b/docs/source/api/grid/workers/index.rst
@@ -1,0 +1,90 @@
+:mod:`grid.workers`
+===================
+
+.. py:module:: grid.workers
+
+
+Submodules
+----------
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
+
+   socketio_client/index.rst
+   socketio_server/index.rst
+
+
+Package Contents
+----------------
+
+.. py:class:: WebsocketIOServerWorker(hook, host: str, port: int, payload=None, id: Union[int, str] = 0, log_msgs: bool = False, verbose: bool = False, data: List[Union[torch.Tensor, AbstractTensor]] = None)
+
+   Bases: :class:`syft.workers.virtual.VirtualWorker`
+
+   Objects of this class can act as a remote worker or as a plain socket IO.
+
+   By adding a payload to the object it will execute it forwarding the messages to the participants in the setup.
+
+   If no payload is added, this object will be a plain socketIO sitting between two clients that implement the
+   protocol.
+
+   .. method:: start(self)
+
+
+
+   .. method:: _send_msg(self, message: bin)
+
+
+
+   .. method:: _recv_msg(self, message: bin)
+
+
+      Forwards a message to the WebsocketIOClientWorker
+
+
+   .. method:: _init_job_thread(self)
+
+
+
+   .. method:: _start_job_loop(loop)
+      :staticmethod:
+
+
+      Switch to new event loop and run forever
+
+
+   .. method:: _start_payload(self)
+
+
+
+   .. method:: terminate(self)
+
+
+
+
+.. py:class:: WebsocketIOClientWorker(hook, host: str, port: int, id: Union[int, str] = 0, is_client_worker: bool = False, log_msgs: bool = False, verbose: bool = False, data: List[Union[torch.Tensor, AbstractTensor]] = None)
+
+   Bases: :class:`syft.workers.virtual.VirtualWorker`
+
+   A worker that forwards a message to a SocketIO server and wait for its response.
+
+   This client then waits until the server returns with a result or an ACK at which point it finishes the
+   _recv_msg operation.
+
+   .. method:: _send_msg(self, message: bin)
+
+
+
+   .. method:: _recv_msg(self, message: bin)
+
+
+
+   .. method:: connect(self)
+
+
+
+   .. method:: disconnect(self)
+
+
+
+

--- a/docs/source/api/grid/workers/socketio_client/index.rst
+++ b/docs/source/api/grid/workers/socketio_client/index.rst
@@ -1,0 +1,35 @@
+:mod:`grid.workers.socketio_client`
+===================================
+
+.. py:module:: grid.workers.socketio_client
+
+
+Module Contents
+---------------
+
+.. py:class:: WebsocketIOClientWorker(hook, host: str, port: int, id: Union[int, str] = 0, is_client_worker: bool = False, log_msgs: bool = False, verbose: bool = False, data: List[Union[torch.Tensor, AbstractTensor]] = None)
+
+   Bases: :class:`syft.workers.virtual.VirtualWorker`
+
+   A worker that forwards a message to a SocketIO server and wait for its response.
+
+   This client then waits until the server returns with a result or an ACK at which point it finishes the
+   _recv_msg operation.
+
+   .. method:: _send_msg(self, message: bin)
+
+
+
+   .. method:: _recv_msg(self, message: bin)
+
+
+
+   .. method:: connect(self)
+
+
+
+   .. method:: disconnect(self)
+
+
+
+

--- a/docs/source/api/grid/workers/socketio_server/index.rst
+++ b/docs/source/api/grid/workers/socketio_server/index.rst
@@ -1,0 +1,54 @@
+:mod:`grid.workers.socketio_server`
+===================================
+
+.. py:module:: grid.workers.socketio_server
+
+
+Module Contents
+---------------
+
+.. py:class:: WebsocketIOServerWorker(hook, host: str, port: int, payload=None, id: Union[int, str] = 0, log_msgs: bool = False, verbose: bool = False, data: List[Union[torch.Tensor, AbstractTensor]] = None)
+
+   Bases: :class:`syft.workers.virtual.VirtualWorker`
+
+   Objects of this class can act as a remote worker or as a plain socket IO.
+
+   By adding a payload to the object it will execute it forwarding the messages to the participants in the setup.
+
+   If no payload is added, this object will be a plain socketIO sitting between two clients that implement the
+   protocol.
+
+   .. method:: start(self)
+
+
+
+   .. method:: _send_msg(self, message: bin)
+
+
+
+   .. method:: _recv_msg(self, message: bin)
+
+
+      Forwards a message to the WebsocketIOClientWorker
+
+
+   .. method:: _init_job_thread(self)
+
+
+
+   .. method:: _start_job_loop(loop)
+      :staticmethod:
+
+
+      Switch to new event loop and run forever
+
+
+   .. method:: _start_payload(self)
+
+
+
+   .. method:: terminate(self)
+
+
+
+

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -1,0 +1,11 @@
+API Reference
+=============
+
+This page contains auto-generated API reference documentation [#f1]_.
+
+.. toctree::
+   :titlesonly:
+
+   /api/grid/index
+
+.. [#f1] Created with `sphinx-autoapi <https://github.com/rtfd/sphinx-autoapi>`_

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,11 +40,7 @@ release = "0.1.0a1"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon"]
-
-# Napoleon settings
-napoleon_google_docstring = True
-napoleon_numpy_docstring = False
+extensions = ["sphinx.ext.napoleon", "autoapi.extension",]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -181,6 +177,9 @@ epub_exclude_files = ["search.html"]
 
 # -- Extension configuration -------------------------------------------------
 
-autodoc_mock_imports = ['numpy','syft','requests_toolbelt',
-                        'websocket','torch','gevent','flask',
-                        'flask_socketio','socketio']
+# AutoApi
+autoapi_dirs = ['../../grid']
+
+# Napoleon settings
+napoleon_google_docstring = True
+napoleon_numpy_docstring = False

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,7 +40,7 @@ release = "0.1.0a1"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.napoleon", "autoapi.extension",]
+extensions = ["sphinx.ext.napoleon", "autoapi.extension"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -184,7 +184,9 @@ epub_exclude_files = ["search.html"]
 
 # AutoApi
 autoapi_keep_files = True
+autoapi_root = 'api'
 autoapi_dirs = ['../../grid']
+
 
 # Napoleon settings
 napoleon_google_docstring = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -83,17 +83,17 @@ html_theme_path = [rtcat_sphinx_theme.get_html_theme_path()]
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-html_theme_options = {
-    "collapse_navigation" : False
-}
+html_theme_options = {"collapse_navigation": False}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
+
 def setup(app):
     app.add_stylesheet("css/theme.css")
+
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
@@ -184,8 +184,8 @@ epub_exclude_files = ["search.html"]
 
 # AutoApi
 autoapi_keep_files = True
-autoapi_root = 'api'
-autoapi_dirs = ['../../grid']
+autoapi_root = "api"
+autoapi_dirs = ["../../grid"]
 
 
 # Napoleon settings

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -83,12 +83,17 @@ html_theme_path = [rtcat_sphinx_theme.get_html_theme_path()]
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    "collapse_navigation" : False
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+def setup(app):
+    app.add_stylesheet("css/theme.css")
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
@@ -178,6 +183,7 @@ epub_exclude_files = ["search.html"]
 # -- Extension configuration -------------------------------------------------
 
 # AutoApi
+autoapi_keep_files = True
 autoapi_dirs = ['../../grid']
 
 # Napoleon settings

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -180,3 +180,7 @@ epub_exclude_files = ["search.html"]
 
 
 # -- Extension configuration -------------------------------------------------
+
+autodoc_mock_imports = ['numpy','syft','requests_toolbelt',
+                        'websocket','torch','gevent','flask',
+                        'flask_socketio','socketio']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,37 +10,7 @@ Welcome to PyGrid's documentation!
    :maxdepth: 2
    :caption: Contents:
 
-Web Socket Client
-=====================
-.. automodule:: grid.websocket_client
-   :members:
-
-Deploy
-=====================
-.. automodule:: grid.deploy.base_deployment
-   :members:
-
-.. automodule:: grid.deploy.heroku_gateway
-   :members:
-
-.. automodule:: grid.deploy.heroku_node
-   :members:
-
-
-Workers
-=====================
-.. automodule:: grid.workers.socketio_client
-   :members:
-
-.. automodule:: grid.workers.socketio_server
-   :members:
-
-
-Utils
-=====================
-.. automodule:: grid.utils
-   :members:
-
+   api/index
 
 Indices and tables
 ==================


### PR DESCRIPTION
# Edit sphinx docs to serve it remotely as well

## Description

Replace auto-docs for autoapi in order to circumvent heavy dependencies such as `torch`.  Now documentation build pipelines do not fail due to excessive memory consumption.

Dependencies:
* sphinx-autoapi


Fixes #374

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] ReadTheDocs pipeline serving edited documentation
    + https://pygridbenardi.readthedocs.io/en/remote_docs/

## Checklist:

- [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
- [ ] New Unit tests added
- [x] Unit tests pass locally with my changes
