### PR TITLE
Update local examples to conform to grid module

### DIFF
--- a/examples/Part 1 - Launch a Grid Node Locally.ipynb
+++ b/examples/Part 1 - Launch a Grid Node Locally.ipynb
@@ -93,21 +93,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING: Grid nodes publish datasets online and are for EXPERIMENTAL use only.Deploy nodes at your own risk. Do not use OpenGrid with any data/models you wish to keep private.\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# WARNING: We should use the same id and port as the one used to start the app!!!\n",
-    "worker = gr.WebsocketGridClient(hook, id=\"bob\", addr=\"http://localhost:3000\")\n",
+    "worker = gr.WebsocketGridClient(hook, id=\"bob\", address=\"http://localhost:3000\")\n",
     "\n",
     "# If you don't connect to the worker you can't send messages to it\n",
     "worker.connect()"
@@ -124,16 +115,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(Wrapper)>[PointerTensor | me:54563500326 -> bob:35720607787]"
+       "(Wrapper)>[PointerTensor | me:62772588857 -> bob:44295910076]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -151,7 +142,7 @@
     {
      "data": {
       "text/plain": [
-       "(Wrapper)>[PointerTensor | me:85022344229 -> bob:31458276515]"
+       "(Wrapper)>[PointerTensor | me:47702907169 -> bob:35336904248]"
       ]
      },
      "execution_count": 4,
@@ -201,7 +192,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,

--- a/examples/Part 3 - Launch a Grid Network Locally.ipynb
+++ b/examples/Part 3 - Launch a Grid Network Locally.ipynb
@@ -45,10 +45,10 @@
     "\n",
     "### Step 4: Start gateway app\n",
     "\n",
-    "Then to start the app just run the `gateway.py` script.\n",
+    "Then to start the app just run the `gateway.py` script. The `--start_local_db` automatically starts a local database so you don't have to configure one yourself.\n",
     "\n",
     "```bash\n",
-    "python gateway.py --port=<port_number>\n",
+    "python gateway.py --start_local_db --port=<port_number>\n",
     "```\n",
     "\n",
     "This will start the app on address: `http://0.0.0.0/<port_number>`.\n",
@@ -123,26 +123,15 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING: Grid nodes publish datasets online and are for EXPERIMENTAL use only.Deploy nodes at your own risk. Do not use OpenGrid with any data/models you wish to keep private.\n",
-      "\n",
-      "WARNING: Grid nodes publish datasets online and are for EXPERIMENTAL use only.Deploy nodes at your own risk. Do not use OpenGrid with any data/models you wish to keep private.\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# WARNING: We should use the same id and port as the one used to start the app!!!\n",
-    "bob = gr.WebsocketGridClient(hook, id=\"bob\", addr=\"http://localhost:3000\")\n",
+    "bob = gr.WebsocketGridClient(hook, id=\"bob\", address=\"http://localhost:3000\")\n",
     "# If you don't connect to the worker you can't send messages to it\n",
     "bob.connect()\n",
     "\n",
     "# WARNING: We should use the same id and port as the one used to start the app!!!\n",
-    "alice = gr.WebsocketGridClient(hook, id=\"alice\", addr=\"http://localhost:3001\")\n",
+    "alice = gr.WebsocketGridClient(hook, id=\"alice\", address=\"http://localhost:3001\")\n",
     "# If you don't connect to the worker you can't send messages to it\n",
     "alice.connect()"
    ]
@@ -158,9 +147,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(Wrapper)>[PointerTensor | me:29680419628 -> bob:81752950542]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "x = th.tensor([1,2,3,4]).send(bob)\n",
     "x"
@@ -174,7 +174,7 @@
     {
      "data": {
       "text/plain": [
-       "(Wrapper)>[PointerTensor | me:35236418521 -> bob:73887043798]"
+       "(Wrapper)>[PointerTensor | me:18859963688 -> bob:42466099899]"
       ]
      },
      "execution_count": 5,
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,17 +234,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[[[PointerTensor | me:68888527406 -> bob:18054511269]],\n",
-       " [[PointerTensor | me:44004693351 -> alice:7320141058]]]"
+       "[[(Wrapper)>[PointerTensor | me:1797921498 -> bob:1664766854]]]"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -255,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,17 +263,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[[[PointerTensor | me:82458720297 -> bob:18054511269]],\n",
-       " [[PointerTensor | me:17594387869 -> alice:23498281646]]]"
+       "[[(Wrapper)>[PointerTensor | me:40497032036 -> bob:1664766854]],\n",
+       " [(Wrapper)>[PointerTensor | me:75678714045 -> alice:96959474372]]]"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -300,7 +299,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Fix problems on notebooks Part-1 and Part-3

## Description

The notebooks regarding local deployment are not working as expected. To run the examples one needs to fix syntax mistakes and performs tasks/configurations that aren't described on the notebook. 

Fixes # 381

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Run notebook `Part 1 - Launch a Grid Node Locally.ipynb` using a clean Kernel
  +  Execute command `python websocket_app.py --start_local_db --id=bob --port=3000` via SHELL
  + Restart  notebook's  kernel and run all cells.
- [ ] Run notebook `Part 3 - Launch a Grid Network Locally.ipynb` using a clean Kernel
  +  Execute command `python gateway.py --port=5000 --start_local_db` via SHELL
  +  Execute command `python websocket_app.py --start_local_db --id=bob --port=3000 --gateway_url=http://localhost:5000` via SHELL
  +  Execute command `python websocket_app.py --start_local_db --id=alice --port=3001 --gateway_url=http://localhost:5000` via SHELL
  + Restart  notebook's  kernel and run all cells.

## Checklist:

- [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
- [ ] New Unit tests added
- [x] Unit tests pass locally with my changes
