### PR TITLE
Start Android example server on `0.0.0.0` to accept all connections

### DIFF
--- a/examples/android/socketio_server_demo.py
+++ b/examples/android/socketio_server_demo.py
@@ -28,5 +28,5 @@ def _payload(location):
 
 if __name__ == "__main__":
     hook = sy.TorchHook(torch)
-    server_worker = WebsocketIOServerWorker(hook, "localhost", 5000, log_msgs=True)
+    server_worker = WebsocketIOServerWorker(hook, "0.0.0.0", 5000, log_msgs=True)
     server_worker.start()


### PR DESCRIPTION
# Pull Request Template

## Description

Using `localhost` or `127.0.0.1` only accepts connections from the local
machine, which won't accept connections from a worker running on an
actual Android device (rather than the Android Studio emulator, for
example.) Starting the server worker with `0.0.0.0` accepts all incoming
connections, including from the local machine.

## Type of change

Please mark options that are relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Ran the example server and connected over the local network from a worker running on an Android phone

## Checklist:

- [X] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
- [ ] New Unit tests added
- [ ] Unit tests pass locally with my changes
