### PR TITLE
Remove unused/outdated import

### DIFF
--- a/grid/websocket_client.py
+++ b/grid/websocket_client.py
@@ -18,7 +18,6 @@ from syft.generic.tensor import AbstractTensor
 from syft.workers.base import BaseWorker
 from syft import WebsocketClientWorker
 from syft.federated.federated_client import FederatedClient
-from syft.codes import MSGTYPE
 from syft.messaging.message import Message
 
 from grid import utils as gr_utils


### PR DESCRIPTION
## Description

Remove unused and outdated import at websocket_client source file.
Nowadays MSGTYPE doesn't exist at PySyft library.

## Type of change

Please mark options that are relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
- [ ] New Unit tests added
- [X] Unit tests pass locally with my changes
