### PR TITLE
Process tensor request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ install:
   - pip3 install flake8-comprehensions
   - pip3 install pep8-naming
   - pip3 install -r dev-requirements.txt >> build.log
-  - python setup.py install >> build.log
 before_script:
   # stop the build if there are Python syntax errors or undefined
   # names

--- a/app/websocket/app/main/auth/user_session.py
+++ b/app/websocket/app/main/auth/user_session.py
@@ -18,6 +18,7 @@ class UserSession(UserMixin):
         """
         self.id = uuid.uuid5(uuid.NAMESPACE_DNS, UserSession.NAMESPACE_DNS)
         self.user = user  # PyGrid UserAuthentication object
+        self.tensor_requests = list()
 
         # If it is the first session of this user at this node.
         if user.username not in hook.local_worker._known_workers:
@@ -34,6 +35,14 @@ class UserSession(UserMixin):
                 ID: Session's ID.
         """
         return self.id
+
+    def save_tensor_request(self, request_msg: tuple):
+        """ Save tensor request at user's request list.
+        
+            Args:
+                request_msg (tuple) : Tuple structure containing tensor id, credentials and reason.
+        """
+        self.tensor_requests.append(request_msg)
 
     @property
     def worker(self) -> sy.VirtualWorker:

--- a/app/websocket/app/main/events/syft_events.py
+++ b/app/websocket/app/main/events/syft_events.py
@@ -4,6 +4,9 @@ from flask_login import current_user
 from .. import local_worker, hook
 from ..persistence.utils import recover_objects, snapshot
 from ..auth import authenticated_only
+from ..auth import UserSession
+
+from syft.exceptions import GetNotPermittedError
 
 
 @authenticated_only
@@ -15,17 +18,24 @@ def forward_binary_message(message: bin) -> bin:
         Returns:
             response (bin) : PySyft binary response.
     """
+    try:
+        ## If worker is empty, load previous database tensors.
+        if not current_user.worker._objects:
+            recover_objects(current_user.worker)
 
-    # If worker is empty, load previous database tensors
-    if not current_user.worker._objects:
-        recover_objects(current_user.worker)
+        # Process message
+        decoded_response = current_user.worker._recv_msg(message)
 
-    # Process message
-    decoded_response = current_user.worker._recv_msg(message)
+        # Save worker state at database
+        snapshot(current_user.worker)
+    except GetNotPermittedError as e:
+        message = sy.serde.deserialize(message, worker=current_user.worker)
 
-    # Save worker state at database
-    snapshot(current_user.worker)
+        # Register this request into tensor owner account.
+        if hasattr(current_user, "save_tensor_request"):
+            current_user.save_request(message._contents)
 
+        decoded_response = sy.serde.serialize(e)
     return decoded_response
 
 

--- a/grid/websocket_client.py
+++ b/grid/websocket_client.py
@@ -18,7 +18,6 @@ from syft.generic.tensor import AbstractTensor
 from syft.workers.base import BaseWorker
 from syft import WebsocketClientWorker
 from syft.federated.federated_client import FederatedClient
-from syft.codes import MSGTYPE
 from syft.messaging.message import Message
 
 from grid import utils as gr_utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ numpy>=1.14.0
 pre-commit
 pytest
 requests
-syft
 websocket_client
 websockets>=7.0
 eventlet==0.25.0
@@ -19,3 +18,5 @@ gevent-websocket
 flask_sockets
 flask_login
 pbr
+git+git://github.com/OpenMined/PySyft@master#syft
+git+git://github.com/OpenMined/proto

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ gevent-websocket
 flask_sockets
 flask_login
 pbr
-git+git://github.com/OpenMined/PySyft@master#syft
-git+git://github.com/OpenMined/proto
+git+https://github.com/OpenMined/PySyft@master#syft
+git+https://github.com/OpenMined/proto

--- a/test/test_api_sockets.py
+++ b/test/test_api_sockets.py
@@ -246,6 +246,29 @@ def test_send_tensor(connected_node):
     assert th.all(th.eq(x_s.get(), x))
 
 
+def test_send_private_tensor(connected_node):
+    x = th.tensor([1.0, 0.4])
+
+    # Private Tensor
+    _x = x.private_tensor(allowed_users=("user"))
+
+    # Pointer to private tensor.
+    p_x = _x.send(connected_node["alice"], user="user")
+    assert p_x.location.id == "alice"
+
+
+def test_get_private_tensor(connected_node):
+    x = th.tensor([1.0, 0.4])
+
+    # Private Tensor
+    _x = x.private_tensor(allowed_users=("user"))
+
+    # Pointer to private tensor.
+    p_x = _x.send(connected_node["alice"], user="user")
+    with pytest.raises(sy.exceptions.GetNotPermittedError):
+        p_x.get()
+
+
 def test_send_tag_tensor(connected_node):
     tag = "#tensor"
     description = "Tensor Description"


### PR DESCRIPTION
# Register Tensor Requests

## Description
Save private tensors requests if a user tries to perform `get()` on a private tensor without using correct credentials.

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Create a Private Tensor, send it to a remote Grid Node.
- [X] Try to retrieve remote private tensor with wrong credentials.
      -  It returns `GetNotPermittedException` to the user.
      - Save tensor request (tensor id, credentials, reason) into the tensor owner account.
- [X] Try to retrieve remote private tensor with correct credentials.

## Checklist:

- [X] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
- [X] New Unit tests added
- [X] Unit tests pass locally with my changes