### PR TITLE
Fix the websocket app procfile module to websocket_app

### DIFF
--- a/app/websocket/Procfile
+++ b/app/websocket/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn -k flask_sockets.worker grid_node:app
+web: gunicorn -k flask_sockets.worker websocket_app:app


### PR DESCRIPTION
# Fix the websocket app procfile module to websocket_app

## Description

The deployment to heroku failed due to a wrong module name in the procfile of the websocket app.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
