### PR TITLE
Add missing proto dependency to the websocket app

### DIFF
--- a/app/websocket/requirements.txt
+++ b/app/websocket/requirements.txt
@@ -1,17 +1,18 @@
 Click==7.0
-Flask==1.0.2
 eventlet==0.24.1
-gunicorn==19.9.0
+Flask==1.0.2
 Flask-Cors==3.0.7
-itsdangerous==1.1.0
 Flask-Sockets==0.2.1
+gevent==1.4.0
+git+git://github.com/OpenMined/Grid@dev
+git+git://github.com/OpenMined/proto
+git+git://github.com/OpenMined/PySyft@master
+gunicorn==19.9.0
+itsdangerous==1.1.0
 Jinja2==2.10.1
 MarkupSafe==1.1.1
-gevent==1.4.0
+psycopg2-binary
 redis==3.2.1
-Werkzeug==0.15.3
-git+git://github.com/OpenMined/PySyft@master
-git+git://github.com/OpenMined/Grid@dev
 torch == 1.3.0
 torchvision
-psycopg2-binary
+Werkzeug==0.15.3


### PR DESCRIPTION
# Add missing proto dependency to the websocket app

## Description

Proto was moved into a separate repo so a dependency needs to be added here.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update