### PR TITLE
Rename folders used in heroku deploy scripts from grid to PyGrid

### DIFF
--- a/grid/deploy/heroku_gateway.py
+++ b/grid/deploy/heroku_gateway.py
@@ -87,10 +87,10 @@ class HerokuGatewayDeployment(BaseDeployment):
         )
 
         self.logs.append("Step 6: copying app code from cloned repo")
-        self.commands.append("cp -r Grid/gateway/* ./")
+        self.commands.append("cp -r PyGrid/gateway/* ./")
 
         self.logs.append("Step 7: removing the rest of the cloned code")
-        self.commands.append("rm -rf Grid")
+        self.commands.append("rm -rf PyGrid")
 
         self.logs.append("Step 8: Initializing new github (for Heroku)")
         self.commands.append("git init")

--- a/grid/deploy/heroku_node.py
+++ b/grid/deploy/heroku_node.py
@@ -91,10 +91,10 @@ class HerokuNodeDeployment(BaseDeployment):
         )
 
         self.logs.append("Step 6: copying app code from cloned repo")
-        self.commands.append("cp -r Grid/app/{}/* ./".format(self.app_type))
+        self.commands.append("cp -r PyGrid/app/{}/* ./".format(self.app_type))
 
         self.logs.append("Step 7: removing the rest of the cloned code")
-        self.commands.append("rm -rf Grid")
+        self.commands.append("rm -rf PyGrid")
 
         self.logs.append("Step 8: Initializing new github (for Heroku)")
         self.commands.append("git init")


### PR DESCRIPTION
# Rename folders used in heroku deploy scripts from grid to PyGrid

## Description

The repo name was changed in the past but the heroku deploy scripts still work with a local folder `grid` after checking out the repo. This is now renamed to `PyGrid`.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
