### PR TITLE
Add egg information to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ gevent-websocket
 flask_sockets
 flask_login
 pbr
-git+https://github.com/OpenMined/PySyft@master#syft
-git+https://github.com/OpenMined/proto
+git+https://github.com/OpenMined/PySyft@master#egg=syft
+git+https://github.com/OpenMined/proto#egg=pysyft_proto


### PR DESCRIPTION
## Description

On my machine (OSX 10.14.6 running python 3.6), while I was able to install
requirements.txt using 'pip install -r requirements.txt', I was not ablee to
do so by running 'pip install .' as the README directs. After some googling,
adding egg information to the github imports in requirements.txt allowed
me to do so. I don't claim to be an expert on this issue, but it worked
for me.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Normal unit tests.

## Checklist:

- [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
- [ ] New Unit tests added
- [x] Unit tests pass locally with my changes
