### PR TITLE
Fix: run_remote_inference

### DIFF
--- a/app/websocket/app/main/events/model_events.py
+++ b/app/websocket/app/main/events/model_events.py
@@ -119,7 +119,7 @@ def run_inference(message: dict) -> str:
         model_output = model(data)
 
         # It the model is a plan, it'll receive a tensor wrapper as a model_output.
-        if hasattr(model_output, "get"):
+        if model_output.is_wrapper:
             model_output = model_output.get()
 
         if isinstance(model_output, tuple):


### PR DESCRIPTION
# Description

Jit/Plans models return a different response type. We need to check if the model inference is a tensor wrapper ( If model is a plan ) or a standard tensor (If model is a Jit).
 
Standard tensors also have the get method, even without children. 

## Type of change

Please mark the options that are relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
- [ ] New Unit tests added
- [X] Unit tests pass locally with my changes