### PR TITLE
Use docker port binding instead of host networking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,55 +6,61 @@ services:
                 - PORT=5000
                 - SECRET_KEY=ineedtoputasecrethere
                 - DATABASE_URL=sqlite:///databasegateway.db
-        network_mode: "host"
+        ports:
+            - 5000:5000        
     redis:
         image: redis:latest
-        network_mode: "host"
+        ports:
+            - 6379:6379
     bob:
         image: openmined/grid-node:latest
         environment:
-                - GRID_NETWORK_URL=http://localhost:5000
+                - GRID_NETWORK_URL=http://gateway:5000
                 - ID=Bob
-                - ADDRESS=http://localhost:3000/
-                - REDISCLOUD_URL=redis:///localhost:6379
+                - ADDRESS=http://bob:3000/
+                - REDISCLOUD_URL=redis:///redis:6379
                 - PORT=3000
         depends_on:
                 - "gateway"
                 - "redis"
-        network_mode: "host"
+        ports:
+            - 3000:3000
     alice:
         image: openmined/grid-node:latest
         environment:
-                - GRID_NETWORK_URL=http://localhost:5000
+                - GRID_NETWORK_URL=http://gateway:5000
                 - ID=Alice
-                - ADDRESS=http://localhost:3001/
-                - REDISCLOUD_URL=redis:///localhost:6379
+                - ADDRESS=http://alice:3001/
+                - REDISCLOUD_URL=redis:///redis:6379
                 - PORT=3001
         depends_on:
                 - "gateway"
                 - "redis"
-        network_mode: "host"
+        ports:
+            - 3001:3001
     bill:
         image: openmined/grid-node:latest
         environment:
-                - GRID_NETWORK_URL=http://localhost:5000
+                - GRID_NETWORK_URL=http://gateway:5000
                 - ID=Bill
-                - ADDRESS=http://localhost:3002/
-                - REDISCLOUD_URL=redis:///localhost:6379
+                - ADDRESS=http://bill:3002/
+                - REDISCLOUD_URL=redis:///redis:6379
                 - PORT=3002
         depends_on:
                 - "gateway"
                 - "redis"
-        network_mode: "host"
+        ports:
+            - 3002:3002
     james:
         image: openmined/grid-node:latest
         environment:
-                - GRID_NETWORK_URL=http://localhost:5000
+                - GRID_NETWORK_URL=http://gateway:5000
                 - ID=James
-                - ADDRESS=http://localhost:3003/
-                - REDISCLOUD_URL=redis:///localhost:6379
+                - ADDRESS=http://james:3003/
+                - REDISCLOUD_URL=redis:///redis:6379
                 - PORT=3003
         depends_on:
                 - "gateway"
                 - "redis"
-        network_mode: "host"
+        ports:
+            - 3003:3003


### PR DESCRIPTION
## Description

This changes binds container ports and uses service names for DNS service discovery instead of localhost (e.g. we don't refer to the gateway as localhost:5000 but gateway:5000).

Solves #460

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] Deploy on Linux
- [ ] Deploy on Windows
- [ ] Deploy on Mac

## Checklist:

- [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
- [ ] New Unit tests added
- [ ] Unit tests pass locally with my changes
