### PR TITLE
Add docker-compose file for Mac to workaround lack of network_mode: host in Docker for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ It will download the latest openmined's docker images and start a grid platform 
 ```
 $ docker-compose up
 ```
+
+On MacOS, you have to work-around the lack of support for `network_mode: host` in Docker for Mac by adding following to your `/etc/hosts`
+```
+127.0.0.1 host.docker.internal
+```
+and running:
+```
+$ docker-compose -f docker-compose-mac.yml up
+```
 #### Kubernetes deployment.
 You can now deploy the grid-gateway and grid-node docker containers on kubernetes. This can be either to a local (minikube) cluster or a remote cluster (GKE, EKS, AKS etc). The steps to setup the cluster can be found in [./k8s/Readme.md](https://github.com/OpenMined/PyGrid/tree/dev/k8s)
 

--- a/docker-compose-mac.yml
+++ b/docker-compose-mac.yml
@@ -1,0 +1,68 @@
+version: '3'
+services:
+    gateway:
+        image: openmined/grid-gateway:latest
+        environment:
+                - PORT=5000
+                - SECRET_KEY=ineedtoputasecrethere
+                - DATABASE_URL=sqlite:///databasegateway.db
+        ports:
+        - 5000:5000
+    redis:
+        image: redis:latest
+        expose:
+        - 6379
+        ports:
+        - 6379:6379
+    bob:
+        image: openmined/grid-node:latest
+        environment:
+                - GRID_NETWORK_URL=http://gateway:5000
+                - ID=Bob
+                - ADDRESS=http://host.docker.internal:3000/
+                - REDISCLOUD_URL=redis://redis:6379
+                - PORT=3000
+        depends_on:
+                - "gateway"
+                - "redis"
+        ports:
+        - 3000:3000
+    alice:
+        image: openmined/grid-node:latest
+        environment:
+                - GRID_NETWORK_URL=http://gateway:5000
+                - ID=Alice
+                - ADDRESS=http://host.docker.internal:3001/
+                - REDISCLOUD_URL=redis://redis:6379
+                - PORT=3001
+        depends_on:
+                - "gateway"
+                - "redis"
+        ports:
+        - 3001:3001
+    bill:
+        image: openmined/grid-node:latest
+        environment:
+                - GRID_NETWORK_URL=http://gateway:5000
+                - ID=Bill
+                - ADDRESS=http://host.docker.internal:3002/
+                - REDISCLOUD_URL=redis://redis:6379
+                - PORT=3002
+        depends_on:
+                - "gateway"
+                - "redis"
+        ports:
+        - 3002:3002
+    james:
+        image: openmined/grid-node:latest
+        environment:
+                - GRID_NETWORK_URL=http://gateway:5000
+                - ID=James
+                - ADDRESS=http://host.docker.internal:3003/
+                - REDISCLOUD_URL=redis://redis:6379
+                - PORT=3003
+        depends_on:
+                - "gateway"
+                - "redis"
+        ports:
+        - 3003:3003


### PR DESCRIPTION
## Description

Add docker-compose file for MacOS users to workaround lack of `network_mode: host` in Docker for Mac.
Fixes # (issue)

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

After these change, running docker-compose on Mac should results in no errors in the console and you shall be able to run the notebooks under https://github.com/OpenMined/PySyft/blob/master/examples/tutorials/grid/federated_learning/mnist/ successfully

## Checklist:

- [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
- [ ] New Unit tests added
- [ ] Unit tests pass locally with my changes
