### PR TITLE
Add gunicorn websocket worker as a Docker ENTRYPOINT

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -6,5 +6,4 @@ WORKDIR /app
 RUN pip3 install -r requirements.txt
 COPY . /app
 WORKDIR /app
-ENTRYPOINT ["gunicorn"]
-CMD ["gateway:app"]
+ENTRYPOINT ["sh", "entrypoint.sh"]

--- a/gateway/entrypoint.sh
+++ b/gateway/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+exec gunicorn -k flask_sockets.worker gateway:app \
+"$@"


### PR DESCRIPTION
# Pull Request Template

## Description

Add a `gunicorn` flask WebSocket worker as a Dockerfile `ENTRYPOINT` on gateway container.

## Type of change

Please mark relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [X] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
- [ ] New Unit tests added
- [X] Unit tests pass locally with my changes