### PR TITLE
Update Docker Publish Workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,7 +8,7 @@ on:
     - cron: '0 2 * * 0' # Weekly on Sundays at 02:00
 
 jobs:
-  update:
+  publish:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Update PyGrid Gateway Image
+      if: github.repository == 'OpenMined/PyGrid'
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: openmined/grid-gateway
@@ -21,6 +22,7 @@ jobs:
         cache: ${{ github.event_name != 'schedule' }}
         workdir: gateway
     - name: Update PyGrid Node Image
+      if: github.repository == 'OpenMined/PyGrid'
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: openmined/grid-node


### PR DESCRIPTION
## Description

One of the advantages of GitHub Actions is that the workflow settings are applied to forks. However, we only need to update the Docker hub images in the main repository. And if the job is triggered on a fork and does not find the secrets, it will fail, as in #472. 

With these settings, the GitHub Actions will only trigger the job in the main repo.

Fixes #486

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
- [ ] New Unit tests added
- [ ] Unit tests pass locally with my changes
