### PR TITLE
FL Process API fixes

### DIFF
--- a/app/websocket/app/main/__init__.py
+++ b/app/websocket/app/main/__init__.py
@@ -12,60 +12,6 @@ from syft.generic.frameworks.types import FrameworkTensor
 from syft.generic.object import AbstractObject
 from syft.generic.pointers.pointer_tensor import PointerTensor
 
-
-def _search(self, query: Union[List[Union[str, int]], str, int]) -> List[PointerTensor]:
-    """Search for a match between the query terms and a tensor's Id, Tag, or Description.
-    Note that the query is an AND query meaning that every item in the list of strings (query*)
-    must be found somewhere on the tensor in order for it to be included in the results.
-    Args:
-        query: A list of strings to match against.
-        me: A reference to the worker calling the search.
-    Returns:
-        A list of PointerTensors.
-    """
-    if isinstance(query, (str, int)):
-        query = [query]
-
-    results = list()
-    for key, obj in self._objects.items():
-        found_something = True
-        for query_item in query:
-            # If deserialization produced a bytes object instead of a string,
-            # make sure it's turned back to a string or a fair comparison.
-            if isinstance(query_item, bytes):
-                query_item = query_item.decode("ascii")
-            query_item = str(query_item)
-
-            match = False
-            if query_item == str(key):
-                match = True
-
-            if isinstance(obj, (AbstractObject, FrameworkTensor)):
-                if obj.tags is not None:
-                    if query_item in obj.tags:
-                        match = True
-
-                if obj.description is not None:
-                    if query_item in obj.description:
-                        match = True
-
-            if not match:
-                found_something = False
-        if found_something:
-            # set garbage_collect_data to False because if we're searching
-            # for a tensor we don't own, then it's probably someone else's
-            # decision to decide when to delete the tensor.
-            ptr = obj.create_pointer(
-                garbage_collect_data=False, owner=sy.local_worker, location=self
-            ).wrap()
-            results.append(ptr)
-
-    return results
-
-
-# Overwrite PySyft search method
-sy.workers.base.BaseWorker.search = _search
-
 # Global variables must be initialized here.
 hook = sy.TorchHook(th)
 local_worker = sy.VirtualWorker(hook, auto_add=False)

--- a/gateway/app/main/events/fl_events.py
+++ b/gateway/app/main/events/fl_events.py
@@ -31,9 +31,13 @@ def host_federated_training(message: dict, socket) -> str:
         serialized_model = unhexlify(
             data.get(MSG_FIELD.MODEL, None).encode()
         )  # Only one
-        serialized_client_plans = data.get(CYCLE.PLANS, None)  # 1 or *
-        serialized_client_protocols = data.get(CYCLE.PROTOCOLS, None)  # 0 or *
-        serialized_avg_plan = data.get(CYCLE.AVG_PLAN, None)  # Only one
+        serialized_client_plans = {
+            k: unhexlify(v.encode()) for k, v in data.get(CYCLE.PLANS, {}).items()
+        }  # 1 or *
+        serialized_client_protocols = {
+            k: unhexlify(v.encode()) for k, v in data.get(CYCLE.PROTOCOLS, {}).items()
+        }  # 0 or *
+        serialized_avg_plan = unhexlify(data.get(CYCLE.AVG_PLAN, None).encode())  # Only one
         client_config = data.get(CYCLE.CLIENT_CONFIG, None)  # Only one
         server_config = data.get(CYCLE.SERVER_CONFIG, None)  # Only one
 

--- a/gateway/app/main/processes/controller.py
+++ b/gateway/app/main/processes/controller.py
@@ -273,10 +273,6 @@ class FLController:
         # Save model initial weights into ModelCheckpoint
         self._model_checkpoints.register(values=model, model=_model)
 
-        # Register new Plans into the database
-        for key, value in client_plans.items():
-            self._plans.register(name=key, value=value, plan_flprocess=fl_process)
-
         # Register new Protocols into the database
         for key, value in client_protocols.items():
             self._protocols.register(
@@ -284,7 +280,11 @@ class FLController:
             )
 
         # Register the average plan into the database
-        self._plans.register(value=value, avg_flprocess=fl_process, is_avg_plan=True)
+        self._plans.register(value=server_averaging_plan, avg_flprocess=fl_process, is_avg_plan=True)
+
+        # Register new Plans into the database
+        for key, value in client_plans.items():
+            self._plans.register(name=key, value=value, plan_flprocess=fl_process)
 
         # Register the client/server setup configs
         self._configs.register(

--- a/gateway/app/main/routes.py
+++ b/gateway/app/main/routes.py
@@ -2,7 +2,7 @@
     All Gateway routes (REST API).
 """
 
-from flask import render_template, Response, request, current_app
+from flask import render_template, Response, request, current_app, send_file
 from math import floor
 import numpy as np
 from scipy.stats import poisson
@@ -12,6 +12,7 @@ import random
 import os
 import requests
 import logging
+import io
 
 from .storage.manager import register_new_node, connected_nodes, delete_node
 from .processes import processes
@@ -346,8 +347,12 @@ def download_model():
             raise InvalidRequestKeyError
 
         _last_checkpoint = processes.get_model_checkpoint(id=model_id)
-        status_code = 200  # Success
-        response_body[MSG_FIELD.MODEL] = _last_checkpoint
+
+        return send_file(
+            io.BytesIO(_last_checkpoint.values),
+            mimetype='application/octet-stream'
+        )
+
     except InvalidRequestKeyError as e:
         status_code = 401  # Unauthorized
         response_body[RESPONSE_MSG.ERROR] = str(e)
@@ -356,7 +361,7 @@ def download_model():
         response_body[RESPONSE_MSG.ERROR] = str(e)
     except Exception as e:
         status_code = 500  # Internal Server Error
-        response_body[RESPONSE_MSG] = str(e)
+        response_body[RESPONSE_MSG.ERROR] = str(e)
 
     return Response(
         json.dumps(response_body), status=status_code, mimetype="application/json"
@@ -627,8 +632,8 @@ def download_plan():
         receive_operations_as = request.args.get("receive_operations_as", None)
 
         # Retrieve Process Entities
-        _plan = processes.get_plan(name=plan_id)
-        _cycle = processes.get_cycle(_plan.fl_process_id)
+        _plan = processes.get_plan(id=plan_id, is_avg_plan=False)
+        _cycle = processes.get_cycle(fl_process_id=_plan.fl_process_id)
         _worker = workers.get(id=worker_id)
         _accepted = processes.validate(_worker.id, _cycle.id, request_key)
 
@@ -638,9 +643,17 @@ def download_plan():
         status_code = 200  # Success
 
         if receive_operations_as == "torchscript":
-            response_body[CYCLE.PLANS] = _plan.value_ts
+            # TODO leave only torchscript plan
+            pass
         else:
-            response_body[CYCLE.PLANS] = _plan.value
+            # TODO leave only list of ops plan
+            pass
+
+        return send_file(
+            io.BytesIO(_plan.value),
+            mimetype='application/octet-stream'
+        )
+
     except InvalidRequestKeyError as e:
         status_code = 401  # Unauthorized
         response_body[RESPONSE_MSG.ERROR] = str(e)
@@ -649,7 +662,7 @@ def download_plan():
         response_body[RESPONSE_MSG.ERROR] = str(e)
     except Exception as e:
         status_code = 500  # Internal Server Error
-        response_body[RESPONSE_MSG] = str(e)
+        response_body[RESPONSE_MSG.ERROR] = str(e)
 
     return Response(
         json.dumps(response_body), status=status_code, mimetype="application/json"

--- a/gateway/app/main/storage/models.py
+++ b/gateway/app/main/storage/models.py
@@ -64,15 +64,15 @@ class Plan(db.Model):
             value (String): String  (List of operations)
             value_ts (String): String (TorchScript)
             is_avg_plan (Boolean) : Boolean flag to indicate if it is the avg plan
-            fl_process_id (Integer, Foreign Key) : Referece to FL Process.
+            fl_process_id (Integer, Foreign Key) : Reference to FL Process.
     """
 
     __tablename__ = "__plan__"
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     name = db.Column(db.String())
-    value = db.Column(db.String())
-    value_ts = db.Column(db.String())
+    value = db.Column(db.LargeBinary)
+    value_ts = db.Column(db.LargeBinary)
     is_avg_plan = db.Column(db.Boolean, default=False)
     fl_process_id = db.Column(db.BigInteger, db.ForeignKey("__fl_process__.id"))
 
@@ -89,15 +89,15 @@ class Protocol(db.Model):
             name (String): protocol name.
             value: String  (List of operations)
             value_ts: String (TorchScript)
-            fl_process_id (Integer, Foreign Key) : Referece to FL Process.
+            fl_process_id (Integer, Foreign Key) : Reference to FL Process.
     """
 
     __tablename__ = "__protocol__"
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     name = db.Column(db.String())
-    value = db.Column(db.String())
-    value_ts = db.Column(db.String())
+    value = db.Column(db.LargeBinary)
+    value_ts = db.Column(db.LargeBinary)
     fl_process_id = db.Column(db.BigInteger, db.ForeignKey("__fl_process__.id"))
 
     def __str__(self):


### PR DESCRIPTION
## Description

While working on integration of FL API with syft.js, I bumped into few blocking issues. This PR tries to fix them:
 * Host FL request wasn't storing FL process ID for the first plan in the list
 * get-plan and get-model requests were not returning model and plan as expected in https://github.com/OpenMined/PyGrid/issues/445 (i.e. as simple binary content, not JSON)

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested with this notebook: https://github.com/OpenMined/PySyft/pull/3185
And this syft.js branch: https://github.com/OpenMined/syft.js/pull/109
After uploading the mode & plan, and running syft.js, one training cycle actually works!

## Checklist:

- [ ] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
- [ ] New Unit tests added
- [x] Unit tests pass locally with my changes
