### PR TITLE
Add build context in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
     gateway:
         image: openmined/grid-gateway:latest
+        build: ./gateway/
         environment:
                 - PORT=5000
                 - SECRET_KEY=ineedtoputasecrethere
@@ -14,6 +15,7 @@ services:
             - 6379:6379
     bob:
         image: openmined/grid-node:latest
+        build: ./app/websocket/
         environment:
                 - GRID_NETWORK_URL=http://gateway:5000
                 - ID=Bob
@@ -40,6 +42,7 @@ services:
             - 3001:3001
     bill:
         image: openmined/grid-node:latest
+        build: ./app/websocket/
         environment:
                 - GRID_NETWORK_URL=http://gateway:5000
                 - ID=Bill
@@ -53,6 +56,7 @@ services:
             - 3002:3002
     james:
         image: openmined/grid-node:latest
+        build: ./app/websocket/
         environment:
                 - GRID_NETWORK_URL=http://gateway:5000
                 - ID=James


### PR DESCRIPTION
# Pull Request Template

## Description

Suggested change allows to build & run images in one shot: `docker-compose up --build`

Fixes N/A

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Running `docker-compose up --build` builds images and starts them, so separate build step is not necessary anymore.

## Checklist:

- [X] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
- [ ] New Unit tests added
- [ ] Unit tests pass locally with my changes
