### PR TITLE
Fix bug in docker-compose.yml file.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
                 - GRID_NETWORK_URL=http://gateway:5000
                 - ID=Bob
                 - ADDRESS=http://bob:3000/
-                - REDISCLOUD_URL=redis:///redis:6379
+                - REDISCLOUD_URL=redis://redis:6379
                 - PORT=3000
         depends_on:
                 - "gateway"
@@ -33,7 +33,7 @@ services:
                 - GRID_NETWORK_URL=http://gateway:5000
                 - ID=Alice
                 - ADDRESS=http://alice:3001/
-                - REDISCLOUD_URL=redis:///redis:6379
+                - REDISCLOUD_URL=redis://redis:6379
                 - PORT=3001
         depends_on:
                 - "gateway"
@@ -47,7 +47,7 @@ services:
                 - GRID_NETWORK_URL=http://gateway:5000
                 - ID=Bill
                 - ADDRESS=http://bill:3002/
-                - REDISCLOUD_URL=redis:///redis:6379
+                - REDISCLOUD_URL=redis://redis:6379
                 - PORT=3002
         depends_on:
                 - "gateway"
@@ -61,7 +61,7 @@ services:
                 - GRID_NETWORK_URL=http://gateway:5000
                 - ID=James
                 - ADDRESS=http://james:3003/
-                - REDISCLOUD_URL=redis:///redis:6379
+                - REDISCLOUD_URL=redis://redis:6379
                 - PORT=3003
         depends_on:
                 - "gateway"


### PR DESCRIPTION
When DATABASE_URL changed to REDISCLOUD_URL three slashes were
mistakenly kept.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I ran docker-compose up before and after on Ubuntu. Then I entered localhost:3000 in the browser. Before my commit the node names (such as Bob and Alice) were not displaying and errors appeared in the terminal running the docker-compose (including redis.exceptions.ConnectionError). After my commit the names are appearing and the errors not. 

## Checklist:

- [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)