### PR TITLE
[WIP] Convert hosted Plan to torchscript and then serve it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .eggs/
 build/
 dist/
+gateway/src/syft/
+src/syft/
 *.swp
 grid.egg-info/
 *.ipynb_checkpoints*
@@ -22,6 +24,7 @@ ipfs.log*
 notebooks/ipfs.log
 .pytest_cache
 .idea/*
+.vscode
 venv/
 test_flask_grid_server.db
 

--- a/gateway/app/main/processes/controller.py
+++ b/gateway/app/main/processes/controller.py
@@ -17,7 +17,13 @@ from ..exceptions import (
 
 import random
 from functools import reduce
-from .helpers import unserialize_model_params, serialize_model_params, serialize_plan, unserialize_plan, translate_plan
+from .helpers import (
+    unserialize_model_params,
+    serialize_model_params,
+    serialize_plan,
+    unserialize_plan,
+    translate_plan,
+)
 import torch as th
 import json
 import logging
@@ -331,7 +337,9 @@ class FLController:
             plan = unserialize_plan(value)
             plan_ts = translate_plan(plan, "torchscript")
             plan_ts_ser = serialize_plan(plan_ts)
-            self._plans.register(name=key, value=value, value_ts=plan_ts_ser, plan_flprocess=fl_process)
+            self._plans.register(
+                name=key, value=value, value_ts=plan_ts_ser, plan_flprocess=fl_process
+            )
 
         # Register the client/server setup configs
         self._configs.register(config=client_config, server_flprocess_config=fl_process)

--- a/gateway/app/main/processes/controller.py
+++ b/gateway/app/main/processes/controller.py
@@ -17,7 +17,7 @@ from ..exceptions import (
 
 import random
 from functools import reduce
-from .helpers import unserialize_model_params, serialize_model_params
+from .helpers import unserialize_model_params, serialize_model_params, serialize_plan, unserialize_plan, translate_plan
 import torch as th
 import json
 import logging
@@ -327,7 +327,11 @@ class FLController:
 
         # Register new Plans into the database
         for key, value in client_plans.items():
-            self._plans.register(name=key, value=value, plan_flprocess=fl_process)
+            # Unserialize client plans to make torchscript variant of plan
+            plan = unserialize_plan(value)
+            plan_ts = translate_plan(plan, "torchscript")
+            plan_ts_ser = serialize_plan(plan_ts)
+            self._plans.register(name=key, value=value, value_ts=plan_ts_ser, plan_flprocess=fl_process)
 
         # Register the client/server setup configs
         self._configs.register(config=client_config, server_flprocess_config=fl_process)

--- a/gateway/app/main/processes/helpers.py
+++ b/gateway/app/main/processes/helpers.py
@@ -15,6 +15,7 @@ from syft.execution.placeholder import PlaceHolder
 # Make fake local worker for serialization
 worker = sy.VirtualWorker(hook=None)
 
+
 def unserialize_model_params(bin: bin):
     """Unserializes model or checkpoint or diff stored in db to list of tensors"""
     state = StatePB()
@@ -52,9 +53,7 @@ def serialize_plan(plan: "Plan"):
 
 def translate_plan(plan: "Plan", variant: str):
     """Translate Plan to specified variant"""
-    translators = {
-        "torchscript": PlanTranslatorTorchscript
-    }
+    translators = {"torchscript": PlanTranslatorTorchscript}
     translator_cls = translators.get(variant, None)
 
     if translator_cls is None:

--- a/gateway/app/main/processes/helpers.py
+++ b/gateway/app/main/processes/helpers.py
@@ -1,7 +1,10 @@
 import syft as sy
 from syft.execution.state import State
+from syft.execution.plan import Plan
+from syft.execution.translation.torchscript import PlanTranslatorTorchscript
 from syft.serde import protobuf
 from syft_proto.execution.v1.state_pb2 import State as StatePB
+from syft_proto.execution.v1.plan_pb2 import Plan as PlanPB
 from syft.execution.placeholder import PlaceHolder
 
 # assume _diff_state produced the same as here
@@ -9,28 +12,52 @@ from syft.execution.placeholder import PlaceHolder
 # see step 7
 # This serialization format will likely to change
 
+# Make fake local worker for serialization
+worker = sy.VirtualWorker(hook=None)
 
 def unserialize_model_params(bin: bin):
     """Unserializes model or checkpoint or diff stored in db to list of tensors"""
     state = StatePB()
     state.ParseFromString(bin)
-    worker = sy.VirtualWorker(hook=None)
     state = protobuf.serde._unbufferize(worker, state)
     model_params = state.tensors()
     return model_params
 
 
-def serialize_model_params(params):
+def serialize_model_params(params: tuple):
     """Serializes list of tensors into State/protobuf"""
     model_params_state = State(
         owner=None,
         state_placeholders=[PlaceHolder().instantiate(param) for param in params],
     )
-
-    # make fake local worker for serialization
-    worker = sy.VirtualWorker(hook=None)
-
     pb = protobuf.serde._bufferize(worker, model_params_state)
     serialized_state = pb.SerializeToString()
-
     return serialized_state
+
+
+def unserialize_plan(bin: bin):
+    """Unserializes a Plan"""
+    pb = PlanPB()
+    pb.ParseFromString(bin)
+    plan = protobuf.serde._unbufferize(worker, pb)
+    return plan
+
+
+def serialize_plan(plan: "Plan"):
+    """Serializes a Plan"""
+    pb = protobuf.serde._bufferize(worker, plan)
+    serialized_plan = pb.SerializeToString()
+    return serialized_plan
+
+
+def translate_plan(plan: "Plan", variant: str):
+    """Translate Plan to specified variant"""
+    translators = {
+        "torchscript": PlanTranslatorTorchscript
+    }
+    translator_cls = translators.get(variant, None)
+
+    if translator_cls is None:
+        return plan
+
+    return plan.translate_with(translator_cls)

--- a/gateway/app/main/routes.py
+++ b/gateway/app/main/routes.py
@@ -664,13 +664,11 @@ def download_plan():
         status_code = 200  # Success
 
         if receive_operations_as == "torchscript":
-            # TODO leave only torchscript plan
-            pass
+            response_body = _plan.value_ts
         else:
-            # TODO leave only list of ops plan
-            pass
+            response_body = _plan.value
 
-        return send_file(io.BytesIO(_plan.value), mimetype="application/octet-stream")
+        return send_file(io.BytesIO(response_body), mimetype="application/octet-stream")
 
     except InvalidRequestKeyError as e:
         status_code = 401  # Unauthorized

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -15,4 +15,5 @@ flask_sqlalchemy
 flask_migrate
 flask_testing
 psycopg2-binary
-git+https://github.com/OpenMined/PySyft@master#egg=syft
+git+git://github.com/OpenMined/syft-proto@vvm/torchscript-plan#egg=syft_proto
+git+https://github.com/OpenMined/PySyft@vvm/torchscript-plan#egg=syft


### PR DESCRIPTION
# Pull Request Template

## Description

Currently we don't have a way to host both "list of ops" and "torchscript" Plans for the same FL process. With this PR, "list of ops" Plan is expected to be hosted, and it is automatically translated into torchscript Plan.

This is tested together with 
https://github.com/OpenMined/PySyft/pull/3263 and updated notebooks located in that PR.

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please see this notebook:
https://github.com/OpenMined/PySyft/blob/vvm/torchscript-plan/examples/experimental/FL%20Training%20Plan/Host%20Plan.ipynb

## Checklist:

- [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
- [ ] New Unit tests added
- [ ] Unit tests pass locally with my changes
