### PR TITLE
Make it easier to build new gateway image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
     gateway:
         image: openmined/grid-gateway:latest
+        build: .
         environment:
                 - PORT=5000
                 - SECRET_KEY=ineedtoputasecrethere


### PR DESCRIPTION
## Description

Make it easier to re-start with new gateway image after code change:
`docker-compose up --build` will re-build gateway image with current changes, if needed, and start up services.

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Using `docker-compose up --build` in my dev cycle (change code > restart docker-compose with --build flag).

## Checklist:

- [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
- [ ] New Unit tests added
- [ ] Unit tests pass locally with my changes
