### PR TITLE
Add ping to speed test endpoint

### DIFF
--- a/app/main/routes/federated.py
+++ b/app/main/routes/federated.py
@@ -63,22 +63,24 @@ def connection_speed_test():
     try:
         _worker_id = request.args.get("worker_id", None)
         _random = request.args.get("random", None)
+        _is_ping = request.args.get("is_ping", None)
 
         if not _worker_id or not _random:
             raise PyGridError
 
         # If GET method
         if request.method == "GET":
-            # Download data sample (1MB)
-            data_sample = b"x" * 67108864  # 64 Megabyte
-            response = {"sample": data_sample}
-            form = MultipartEncoder(response)
-            return Response(form.to_string(), mimetype=form.content_type)
-        elif request.method == "POST":  # Otherwise, it's POST method
-            if len(request.files) == 1:
-                status_code = 200  # Success
+            if _is_ping is None:
+                # Download data sample (64MB)
+                data_sample = b"x" * 67108864  # 64 Megabyte
+                response = {"sample": data_sample}
+                form = MultipartEncoder(response)
+                return Response(form.to_string(), mimetype=form.content_type)
             else:
-                raise PyGridError
+                status_code = 200  # Success
+        elif request.method == "POST":  # Otherwise, it's POST method
+            status_code = 200  # Success
+
     except PyGridError as e:
         status_code = 400  # Bad Request
         response_body[RESPONSE_MSG.ERROR] = str(e)


### PR DESCRIPTION
## Description

Add `is_ping` parameter that will just return status 200 OK
This is to test simple ping w/o downloading 64MB file.

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested opening /federated/speed-test?worker_id=xxx&random=123&is_ping=1

## Checklist:

- [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
- [ ] New Unit tests added
- [ ] Unit tests pass locally with my changes
