### PR TITLE
Update to latest PySyft/State and fix typo

### DIFF
--- a/app/main/controller/fl_controller.py
+++ b/app/main/controller/fl_controller.py
@@ -152,7 +152,7 @@ class FLController:
                 fl_process_id=_fl_process.id, is_completed=True
             )
 
-            _max_cycles = server_config.get["num_cycles"]
+            _max_cycles = server_config["num_cycles"]
 
             response = {
                 CYCLE.STATUS: "rejected",

--- a/app/main/models/model_manager.py
+++ b/app/main/models/model_manager.py
@@ -69,7 +69,6 @@ class ModelManager:
     def serialize_model_params(params):
         """Serializes list of tensors into State/protobuf"""
         model_params_state = State(
-            owner=None,
             state_placeholders=[PlaceHolder().instantiate(param) for param in params],
         )
 


### PR DESCRIPTION
# Pull Request Template

## Description

Small fixes:
 * Typo: `server_config.get["num_cycles"]` -> `server_config["num_cycles"]`
 * State constructor arguments changed in PySyft (owner is removed)

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Executed FL example notebooks against it.

## Checklist:

- [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
- [ ] New Unit tests added
- [ ] Unit tests pass locally with my changes
