### PR TITLE
Bump werkzeug version to 0.15.5

### DIFF
--- a/pip-dep/requirements.txt
+++ b/pip-dep/requirements.txt
@@ -18,5 +18,5 @@ psycopg2-binary
 requests==2.22.0
 requests_toolbelt
 syft==0.2.6
-Werkzeug==0.15.3
+Werkzeug==0.15.5
 


### PR DESCRIPTION
## Description
It bumps werkzeug version to 0.15.5.

Fixes #585 

## Affected Dependencies
There are no dependencies affected.

## How has this been tested?
I installed a fresh virtual env before and after this changes. 
- **Before**: It shows the stack trace mentioned in #585;
- **After**: It runs as expected.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
