### PR TITLE
Accept cycle requests when server_config.num_cycles = 0

### DIFF
--- a/grid/app/main/controller/fl_controller.py
+++ b/grid/app/main/controller/fl_controller.py
@@ -118,7 +118,7 @@ class FLController:
         _accepted = (
             (server_config["num_cycles"] == 0)
             or (not _assigned)
-            and _comp_bandwith
+            and _comp_bandwidth
             and _allowed
         )
         if _accepted:

--- a/grid/app/main/controller/fl_controller.py
+++ b/grid/app/main/controller/fl_controller.py
@@ -115,7 +115,12 @@ class FLController:
         #     >= _cycle.sequence
         # )
 
-        _accepted = (not _assigned) and _comp_bandwith and _allowed
+        _accepted = (
+            (server_config["num_cycles"] == 0)
+            or (not _assigned)
+            and _comp_bandwith
+            and _allowed
+        )
         if _accepted:
             # Assign
             # 1 - Generate new request key


### PR DESCRIPTION
## Description
`server_config.num_cycles = 0` now acts like a flag for PyGrid to accept all cycle requests.

See #587.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
