### PR TITLE
Take GRID_PORT into account in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-exec gunicorn -k flask_sockets.worker "grid.__main__:app" \
+exec gunicorn -b 0.0.0.0:${GRID_PORT:-5000} -k flask_sockets.worker "grid.__main__:app" \
 "$@"


### PR DESCRIPTION
## Description
docker-compose way is kinda broken because "gateway" runs on 8000 (gunicorn default) instead of configured/exposed GRID_PORT.

## Affected Dependencies
n/a

## How has this been tested?
Manually run `docker-compose up`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [] My changes are covered by tests
