### PR TITLE
update conditions to accept cycle requests

### DIFF
--- a/grid/app/main/sfl/controller/fl_controller.py
+++ b/grid/app/main/sfl/controller/fl_controller.py
@@ -115,12 +115,8 @@ class FLController:
         #     >= _cycle.sequence
         # )
 
-        _accepted = (
-            (server_config["num_cycles"] == 0)
-            or (not _assigned)
-            and _comp_bandwidth
-            and _allowed
-        )
+        _accepted = (not _assigned) and _comp_bandwidth and _allowed
+
         if _accepted:
             # Assign
             # 1 - Generate new request key

--- a/grid/app/main/sfl/cycles/cycle_manager.py
+++ b/grid/app/main/sfl/cycles/cycle_manager.py
@@ -157,8 +157,6 @@ class CycleManager:
             worker_id=worker_id, request_key=request_key
         )
 
-
-
         if not _worker_cycle:
             raise ProcessLookupError
 
@@ -305,7 +303,9 @@ class CycleManager:
         max_cycles = server_config.get("num_cycles")
         if completed_cycles_num < max_cycles:
             # make new cycle
-            _new_cycle = self.create(cycle.fl_process_id, cycle.version, server_config.get('cycle_length'))
+            _new_cycle = self.create(
+                cycle.fl_process_id, cycle.version, server_config.get("cycle_length")
+            )
             logging.info("new cycle: %s" % str(_new_cycle))
         else:
             logging.info("FL is done!")

--- a/grid/app/main/sfl/syft_assets/plan_manager.py
+++ b/grid/app/main/sfl/syft_assets/plan_manager.py
@@ -125,10 +125,7 @@ class PlanManager:
             "tfjs": PlanTranslatorTfjs,
         }
 
-        if (
-            variant not in type_translators
-            and variant not in fw_translators
-        ):
+        if variant not in type_translators and variant not in fw_translators:
             raise PlanTranslationError
 
         plan_copy = plan.copy()
@@ -141,7 +138,7 @@ class PlanManager:
         if variant in fw_translators:
             # First, leave only default translation
             for name, cls in type_translators.items():
-                if name != 'default':
+                if name != "default":
                     plan_copy.remove_translation(cls)
             # Set actions to be specific type
             plan_copy.base_framework = variant


### PR DESCRIPTION
## Description
Use `server_config.num_cycles = 0` as a flag to accept cycle requests creates new cycles endlessly. Since we adopted the `max_diffs` and `min_diffs` solution, we no longer need this.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
