### PR TITLE
Fix static FL "get-model" route

### DIFF
--- a/grid/app/main/routes/sfl/routes.py
+++ b/grid/app/main/routes/sfl/routes.py
@@ -469,7 +469,10 @@ def get_model():
         version = request.args.get("version", None)
         checkpoint = request.args.get("checkpoint", None)
 
-        _fl_process = process_manager.get(name=name, version=version)
+        process_query = {"name": name}
+        if version:
+            process_query["version"] = version
+        _fl_process = process_manager.last(**process_query)
         _model = model_manager.get(fl_process_id=_fl_process.id)
         _model_checkpoint = model_manager.load(model_id=_model.id, id=checkpoint)
 
@@ -480,6 +483,7 @@ def get_model():
     except Exception as e:
         status_code = 500  # Internal Server Error
         response_body[RESPONSE_MSG.ERROR] = str(e)
+        logging.error("Exception in get-model", exc_info=e)
 
     return Response(
         json.dumps(response_body), status=status_code, mimetype="application/json"

--- a/grid/app/main/sfl/controller/fl_controller.py
+++ b/grid/app/main/sfl/controller/fl_controller.py
@@ -103,7 +103,9 @@ class FLController:
 
         # Check if already exists a relation between the worker and the cycle.
         _assigned = cycle_manager.is_assigned(worker.id, _cycle.id)
-        logging.info(f"Worker {worker.id} is already assigned to cycle {_cycle.id}: {_assigned}")
+        logging.info(
+            f"Worker {worker.id} is already assigned to cycle {_cycle.id}: {_assigned}"
+        )
 
         # Check bandwidth
         _comp_bandwidth = worker_manager.is_eligible(worker.id, server_config)

--- a/grid/app/main/sfl/workers/worker_manager.py
+++ b/grid/app/main/sfl/workers/worker_manager.py
@@ -7,6 +7,7 @@ from ...exceptions import WorkerNotFoundError
 
 import logging
 
+
 class WorkerManager:
     def __init__(self):
         self._workers = Warehouse(Worker)
@@ -55,7 +56,9 @@ class WorkerManager:
                 result: Boolean flag.
         """
         _worker = self._workers.first(id=worker_id)
-        logging.info(f"Checking worker [{_worker}] against server_config [{server_config}]")
+        logging.info(
+            f"Checking worker [{_worker}] against server_config [{server_config}]"
+        )
 
         # Check bandwidth
         _comp_bandwidth = (


### PR DESCRIPTION
## Description
Fixes "/get-model" route that yields 500 error because 
process_manager.get() returns a list instead of expected FLProcess object.

## Affected Dependencies
n/a

## How has this been tested?
Ran notebook that fetches the model by name/version/checkpoint.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
