### PR TITLE
Fix invalid ModelCheckpoint DB field access

### DIFF
--- a/grid/app/main/routes/sfl/routes.py
+++ b/grid/app/main/routes/sfl/routes.py
@@ -183,7 +183,7 @@ def download_model():
         _last_checkpoint = model_manager.load(model_id=model_id)
 
         return send_file(
-            io.BytesIO(_last_checkpoint.values), mimetype="application/octet-stream"
+            io.BytesIO(_last_checkpoint.value), mimetype="application/octet-stream"
         )
 
     except InvalidRequestKeyError as e:
@@ -498,7 +498,7 @@ def get_model():
         _model_checkpoint = model_manager.load(**checkpoint_query)
 
         return send_file(
-            io.BytesIO(_model_checkpoint.values), mimetype="application/octet-stream"
+            io.BytesIO(_model_checkpoint.value), mimetype="application/octet-stream"
         )
 
     except ModelNotFoundError as e:

--- a/grid/app/main/sfl/cycles/cycle_manager.py
+++ b/grid/app/main/sfl/cycles/cycle_manager.py
@@ -238,7 +238,7 @@ class CycleManager:
         logging.info("model id: %d" % model_id)
         _checkpoint = model_manager.load(model_id=model_id)
         logging.info("current checkpoint: %s" % str(_checkpoint))
-        model_params = model_manager.unserialize_model_params(_checkpoint.values)
+        model_params = model_manager.unserialize_model_params(_checkpoint.value)
         logging.info("model params shapes: %s" % str([p.shape for p in model_params]))
 
         reports_to_average = self._worker_cycles.query(


### PR DESCRIPTION
## Description
Some model-related requests were failing due to invalid (old) DB field name of ModelCheckpoint (`values` instead of new `value`).

## Affected Dependencies
n/a

## How has this been tested?
Executed "Part 01 - Create Plan" notebook from PySyft.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
