### PR TITLE
Make speed fields in cycle-request optional; rename get-model route

### DIFF
--- a/grid/app/main/events/sfl/fl_events.py
+++ b/grid/app/main/events/sfl/fl_events.py
@@ -6,7 +6,7 @@ import uuid
 from binascii import unhexlify
 
 from ...core.codes import CYCLE, MODEL_CENTRIC_FL_EVENTS, MSG_FIELD, RESPONSE_MSG
-from ...core.exceptions import CycleNotFoundError, MaxCycleLimitExceededError
+from ...core.exceptions import CycleNotFoundError, MaxCycleLimitExceededError, PyGridError
 from ...sfl.auth.federated import verify_token
 from ...sfl.processes import process_manager
 from ...sfl.workers import worker_manager
@@ -180,16 +180,29 @@ def cycle_request(message: dict, socket=None) -> str:
         worker_id = data.get(MSG_FIELD.WORKER_ID, None)
         name = data.get(MSG_FIELD.MODEL, None)
         version = data.get(CYCLE.VERSION, None)
-        ping = int(data.get(CYCLE.PING, None))
-        download = float(data.get(CYCLE.DOWNLOAD, None))
-        upload = float(data.get(CYCLE.UPLOAD, None))
 
         # Retrieve the worker
         worker = worker_manager.get(id=worker_id)
 
-        worker.ping = ping
-        worker.avg_download = download
-        worker.avg_upload = upload
+        # Request fields to worker's DB fields mapping
+        fields_map = {
+            CYCLE.PING: "ping",
+            CYCLE.DOWNLOAD: "avg_download",
+            CYCLE.UPLOAD: "avg_upload",
+        }
+        requires_speed_fields = requires_speed_test(name, version)
+
+        # Check and save connection speed to DB
+        for request_field, db_field in fields_map.items():
+            if request_field in data:
+                value = data.get(request_field)
+                if not isinstance(value, (float, int)) or value < 0:
+                    raise PyGridError(f"'{request_field}' needs to be a positive number")
+                setattr(worker, db_field, float(value))
+            elif requires_speed_fields:
+                # Require fields to present when FL model has speed req's
+                raise PyGridError(f"'{request_field}' is required")
+
         worker_manager.update(worker)  # Update database worker attributes
 
         # The last time this worker was assigned for this model/version.

--- a/grid/app/main/events/sfl/fl_events.py
+++ b/grid/app/main/events/sfl/fl_events.py
@@ -6,7 +6,11 @@ import uuid
 from binascii import unhexlify
 
 from ...core.codes import CYCLE, MODEL_CENTRIC_FL_EVENTS, MSG_FIELD, RESPONSE_MSG
-from ...core.exceptions import CycleNotFoundError, MaxCycleLimitExceededError, PyGridError
+from ...core.exceptions import (
+    CycleNotFoundError,
+    MaxCycleLimitExceededError,
+    PyGridError,
+)
 from ...sfl.auth.federated import verify_token
 from ...sfl.processes import process_manager
 from ...sfl.workers import worker_manager
@@ -197,7 +201,9 @@ def cycle_request(message: dict, socket=None) -> str:
             if request_field in data:
                 value = data.get(request_field)
                 if not isinstance(value, (float, int)) or value < 0:
-                    raise PyGridError(f"'{request_field}' needs to be a positive number")
+                    raise PyGridError(
+                        f"'{request_field}' needs to be a positive number"
+                    )
                 setattr(worker, db_field, float(value))
             elif requires_speed_fields:
                 # Require fields to present when FL model has speed req's

--- a/grid/app/main/routes/sfl/routes.py
+++ b/grid/app/main/routes/sfl/routes.py
@@ -468,7 +468,7 @@ def fl_cycle_application_decision():
     )
 
 
-@model_centric.route("/get-model", methods=["GET"])
+@model_centric.route("/retrieve-model", methods=["GET"])
 def get_model():
     """Request a download of a model."""
 

--- a/grid/app/main/sfl/workers/worker_manager.py
+++ b/grid/app/main/sfl/workers/worker_manager.py
@@ -66,8 +66,12 @@ class WorkerManager:
 
         # Check bandwidth
         _comp_bandwidth = (
-            _worker.avg_upload >= server_config["minimum_upload_speed"]
-        ) and (_worker.avg_download >= server_config["minimum_download_speed"])
+            "minimum_upload_speed" not in server_config
+            or _worker.avg_upload >= server_config["minimum_upload_speed"]
+        ) and (
+            "minimum_download_speed" not in server_config
+            or _worker.avg_download >= server_config["minimum_download_speed"]
+        )
 
         logging.info(f"Result of bandwidth check: {_comp_bandwidth}")
         return _comp_bandwidth

--- a/test/test_static_api_sockets.py
+++ b/test/test_static_api_sockets.py
@@ -309,7 +309,7 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
                 "version": "0.1.0",
                 "ping": 1,
                 "download": 5,
-                "upload": 5
+                "upload": 5,
             },
         }
         response = await send_ws_message(cycle_req)

--- a/test/test_static_api_sockets.py
+++ b/test/test_static_api_sockets.py
@@ -287,6 +287,35 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
         self.assertIsNotNone(worker_id)
         self.assertTrue(requires_speed_test)
 
+        # Speed must be required in cycle-request
+        cycle_req = {
+            "type": "model_centric/cycle-request",
+            "data": {
+                "worker_id": worker_id,
+                "model": "my-federated-model-2",
+                "version": "0.1.0",
+            },
+        }
+        response = await send_ws_message(cycle_req)
+        self.assertIsNotNone(response["data"].get("error"))
+        self.assertEqual(response["data"].get("status"), "rejected")
+
+        # Should accept into cycle if all speed fields are sent
+        cycle_req = {
+            "type": "model_centric/cycle-request",
+            "data": {
+                "worker_id": worker_id,
+                "model": "my-federated-model-2",
+                "version": "0.1.0",
+                "ping": 1,
+                "download": 5,
+                "upload": 5
+            },
+        }
+        response = await send_ws_message(cycle_req)
+        self.assertIsNone(response["data"].get("error"))
+        self.assertEqual(response["data"].get("status"), "accepted")
+
     async def test_requires_speed_test_false(self):
 
         client_config = {
@@ -335,3 +364,16 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
 
         self.assertIsNotNone(worker_id)
         self.assertFalse(requires_speed_test)
+
+        # Speed is not required in cycle-request
+        cycle_req = {
+            "type": "model_centric/cycle-request",
+            "data": {
+                "worker_id": worker_id,
+                "model": "my-federated-model-3",
+                "version": "0.1.0",
+            },
+        }
+        response = await send_ws_message(cycle_req)
+        self.assertIsNone(response["data"].get("error"))
+        self.assertEqual(response["data"].get("status"), "accepted")


### PR DESCRIPTION
## Description
Changes:
 * make ping, download, upload fields optional if speed test is not required
 * fix speed comparison in cycle-request when server_config doesn't have required speed values
 * change `GET /model_centric/get-model[model_name, model_version, checkpoint]` to `GET /model_centric/retrieve-model[model_name, model_version, checkpoint]`

## Affected Dependencies
PySyft is updated with new route: https://github.com/OpenMined/PySyft/pull/3890

## How has this been tested?
Unit tests & e2e run of PySyft static FL notebooks

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
