### PR TITLE
add node id in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ To start the PyGrid Node manually, run:
 
 ```
 cd apps/node
-./run.sh --port 5000 --start_local_db
+./run.sh --id bob --port 5000 --start_local_db
 ```
 
 You can pass the arguments or use environment variables to set the network configs.


### PR DESCRIPTION
## Description

To start the PyGrid Node manually, run:
`./run.sh --port 5000 --start_local_db`

Small addition, but not having id causes errors in multiple functionalities and tutorials in pysyft. 


## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
