### PR TITLE
Update default ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,15 +133,15 @@ You can pass the arguments or use environment variables to set the network confi
 
 - `-h, --help` - Shows the help message and exit
 - `-p [PORT], --port [PORT]` - Port to run server on (default: 5000)
-- `--host [HOST]` - The Network host
+- `--host [HOST]` - The Node host
 - `--num_replicas [NUM]` - The number of replicas to provide fault tolerance to model hosting
 - `--id [ID]` - The ID of the Node
 - `--start_local_db` - If this flag is used a SQLAlchemy DB URI is generated to use a local db
 
 **Environment Variables**
 
-- `GRID_PORT` - Port to run server on
-- `GRID_HOST` - The Network host
+- `GRID_NODE_PORT` - Port to run server on
+- `GRID_NODE_HOST` - The Node host
 - `NUM_REPLICAS` - Number of replicas to provide fault tolerance to model hosting
 - `DATABASE_URL` - The Node database URL
 - `SECRET_KEY` - The secret key
@@ -166,8 +166,8 @@ You can pass the arguments or use environment variables to set the network confi
 
 **Environment Variables**
 
-- `GRIDNETWORK_WS_PORT` - Port to run server on
-- `GRIDNETWORK_WS_HOST` - The Network host
+- `GRID_NETWORK_PORT` - Port to run server on
+- `GRID_NETWORK_HOST` - The Network host
 - `DATABASE_URL` - The Network database URL
 - `SECRET_KEY` - The secret key
 

--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ You can pass the arguments or use environment variables to set the network confi
 
 **Environment Variables**
 
-- `GRID_NETWORK_PORT` - Port to run server on
-- `GRID_NETWORK_HOST` - The Network host
+- `GRID_PORT` - Port to run server on
+- `GRID_HOST` - The Network host
 - `NUM_REPLICAS` - Number of replicas to provide fault tolerance to model hosting
 - `DATABASE_URL` - The Node database URL
 - `SECRET_KEY` - The secret key
@@ -152,7 +152,7 @@ To start the PyGrid Network manually, run:
 
 ```
 cd apps/network
-./run.sh --port 5000 --start_local_db
+./run.sh --port 7000 --start_local_db
 ```
 
 You can pass the arguments or use environment variables to set the network configs.
@@ -160,14 +160,14 @@ You can pass the arguments or use environment variables to set the network confi
 **Arguments**
 
 - `-h, --help` - Shows the help message and exit
-- `-p [PORT], --port [PORT]` - Port to run server on (default: 5000)
+- `-p [PORT], --port [PORT]` - Port to run server on (default: 7000)
 - `--host [HOST]` - The Network host
 - `--start_local_db` - If this flag is used a SQLAlchemy DB URI is generated to use a local db
 
 **Environment Variables**
 
-- `GRID_NETWORK_PORT` - Port to run server on
-- `GRID_NETWORK_HOST` - The Network host
+- `GRIDNETWORK_WS_PORT` - Port to run server on
+- `GRIDNETWORK_WS_HOST` - The Network host
 - `DATABASE_URL` - The Network database URL
 - `SECRET_KEY` - The secret key
 

--- a/apps/network/src/__main__.py
+++ b/apps/network/src/__main__.py
@@ -17,8 +17,8 @@ required.add_argument(
     "--port",
     "-p",
     type=int,
-    help="Port number of the socket.io server, e.g. --port=8777. Default is os.environ.get('GRIDNETWORK_WS_PORT', None).",
-    default=os.environ.get("GRIDNETWORK_WS_PORT", None),
+    help="Port number of the socket.io server, e.g. --port=7000. Default is os.environ.get('GRIDNETWORK_WS_PORT', 7000).",
+    default=os.environ.get("GRIDNETWORK_WS_PORT", 7000),
     required=True,
 )
 

--- a/apps/network/src/__main__.py
+++ b/apps/network/src/__main__.py
@@ -19,7 +19,6 @@ required.add_argument(
     type=int,
     help="Port number of the socket.io server, e.g. --port=7000. Default is os.environ.get('GRIDNETWORK_WS_PORT', 7000).",
     default=os.environ.get("GRIDNETWORK_WS_PORT", 7000),
-    required=True,
 )
 
 optional.add_argument(

--- a/apps/network/src/__main__.py
+++ b/apps/network/src/__main__.py
@@ -17,15 +17,15 @@ required.add_argument(
     "--port",
     "-p",
     type=int,
-    help="Port number of the socket.io server, e.g. --port=7000. Default is os.environ.get('GRIDNETWORK_WS_PORT', 7000).",
-    default=os.environ.get("GRIDNETWORK_WS_PORT", 7000),
+    help="Port number of the socket.io server, e.g. --port=7000. Default is os.environ.get('GRID_NETWORK_PORT', 7000).",
+    default=os.environ.get("GRID_NETWORK_PORT", 7000),
 )
 
 optional.add_argument(
     "--host",
     type=str,
-    help="GridNerwork host, e.g. --host=0.0.0.0. Default is os.environ.get('GRIDNETWORK_WS_HOST','http://0.0.0.0').",
-    default=os.environ.get("GRIDNETWORK_WS_HOST", "0.0.0.0"),
+    help="GridNerwork host, e.g. --host=0.0.0.0. Default is os.environ.get('GRID_NETWORK_HOST','http://0.0.0.0').",
+    default=os.environ.get("GRID_NETWORK_HOST", "0.0.0.0"),
 )
 
 optional.add_argument(

--- a/apps/node/src/__main__.py
+++ b/apps/node/src/__main__.py
@@ -20,8 +20,8 @@ parser.add_argument(
     "--port",
     "-p",
     type=int,
-    help="Port number of the socket server, e.g. --port=8777. Default is os.environ.get('GRID_PORT', None).",
-    default=os.environ.get("GRID_PORT", None),
+    help="Port number of the socket server, e.g. --port=5000. Default is os.environ.get('GRID_PORT', 5000).",
+    default=os.environ.get("GRID_PORT", 5000),
 )
 
 parser.add_argument(
@@ -34,7 +34,7 @@ parser.add_argument(
 parser.add_argument(
     "--network",
     type=str,
-    help="Grid Network address, e.g. --network=0.0.0.0:5000. Default is os.environ.get('NETWORK',None).",
+    help="Grid Network address, e.g. --network=0.0.0.0:7000. Default is os.environ.get('NETWORK',None).",
     default=os.environ.get("NETWORK", None),
 )
 

--- a/apps/node/src/__main__.py
+++ b/apps/node/src/__main__.py
@@ -20,15 +20,15 @@ parser.add_argument(
     "--port",
     "-p",
     type=int,
-    help="Port number of the socket server, e.g. --port=5000. Default is os.environ.get('GRID_PORT', 5000).",
-    default=os.environ.get("GRID_PORT", 5000),
+    help="Port number of the socket server, e.g. --port=5000. Default is os.environ.get('GRID_NODE_PORT', 5000).",
+    default=os.environ.get("GRID_NODE_PORT", 5000),
 )
 
 parser.add_argument(
     "--host",
     type=str,
-    help="Grid node host, e.g. --host=0.0.0.0. Default is os.environ.get('GRID_HOST','0.0.0.0').",
-    default=os.environ.get("GRID_HOST", "0.0.0.0"),
+    help="Grid node host, e.g. --host=0.0.0.0. Default is os.environ.get('GRID_NODE_HOST','0.0.0.0').",
+    default=os.environ.get("GRID_NODE_HOST", "0.0.0.0"),
 )
 
 parser.add_argument(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,60 +4,60 @@ services:
     image: openmined/grid-network:production
     build: ./apps/network
     environment:
-      - PORT=5000
+      - PORT=7000
       - SECRET_KEY=ineedtoputasecrethere
       - DATABASE_URL=sqlite:///databasenetwork.db
     ports:
-      - 5000:5000
+      - 7000:7000
   bob:
     image: openmined/grid-node:production
     build: ./apps/node
     environment:
       - NODE_ID=Bob
-      - ADDRESS=http://bob:3000/
-      - PORT=3000
-      - NETWORK=http://network:5000
+      - ADDRESS=http://bob:5000/
+      - PORT=5000
+      - NETWORK=http://network:7000
       - DATABASE_URL=sqlite:///databasenode.db
     depends_on:
       - 'network'
     ports:
-      - 3000:3000
+      - 5000:5000
   alice:
     image: openmined/grid-node:production
     build: ./apps/node
     environment:
       - NODE_ID=Alice
-      - ADDRESS=http://alice:3001/
-      - PORT=3001
-      - NETWORK=http://network:5000
+      - ADDRESS=http://alice:5001/
+      - PORT=5001
+      - NETWORK=http://network:7000
       - DATABASE_URL=sqlite:///databasenode.db
     depends_on:
       - 'network'
     ports:
-      - 3001:3001
+      - 5001:5001
   bill:
     image: openmined/grid-node:production
     build: ./apps/node
     environment:
       - NODE_ID=Bill
-      - ADDRESS=http://bill:3002/
-      - PORT=3002
-      - NETWORK=http://network:5000
+      - ADDRESS=http://bill:5002/
+      - PORT=5002
+      - NETWORK=http://network:7000
       - DATABASE_URL=sqlite:///databasenode.db
     depends_on:
       - 'network'
     ports:
-      - 3002:3002
+      - 5002:5002
   james:
     image: openmined/grid-node:production
     build: ./apps/node
     environment:
       - NODE_ID=James
-      - ADDRESS=http://james:3003/
-      - PORT=3003
-      - NETWORK=http://network:5000
+      - ADDRESS=http://james:5003/
+      - PORT=5003
+      - NETWORK=http://network:7000
       - DATABASE_URL=sqlite:///databasenode.db
     depends_on:
       - 'network'
     ports:
-      - 3003:3003
+      - 5003:5003


### PR DESCRIPTION
## Description
Currently according to README both PyGrid Node and Network use `5000` as default port when started via `run.sh`, however when started via docker-compose Node uses `300x` and Network uses `5000`. This leads to situation when model-centric tutorial/demos work or not depending on how PyGrid is started (w/ or w/o docker).
(Additionally, it's not so clear from Network error what's wrong with model-centric API request)
We better assign consistent default ports to PyGrid Node and PyGrid Network so they do not collide.

## Affected Dependencies
There're model-centric and grid tutorials in PySyft and demos in KotlinSyft, SwiftSyft, syft.js that use port 5000.
After model-centric API was moved to PyGrid Node, we didn't update ports to 3000 there.
If we put Node to 5xxx and Network to 7xxx, grid tutorials in PySyft needs update because they use 3xxx for Node and 5000 for Network.
But if we put Node on 3xxx and Network on 5000, model-centric tutorials/demos need update.
So both variants are breaking change either for model-centric or grid tutorials.
Please advice which is worse :)
p.s.
Another solution is to make Network to forward model-centric API to Nodes :)

## How has this been tested?
Executed Node and Network via run.sh and docker-compose, checked ports.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
