### PR TITLE
Add flask-lambda-python36 as dev dep in node

### DIFF
--- a/apps/node/poetry.lock
+++ b/apps/node/poetry.lock
@@ -400,6 +400,17 @@ version = "0.9.3"
 Flask = "*"
 
 [[package]]
+category = "dev"
+description = "Python3.6+ module to make Flask compatible with AWS Lambda"
+name = "flask-lambda-python36"
+optional = false
+python-versions = "*"
+version = "0.1.0"
+
+[package.dependencies]
+Flask = ">=0.10"
+
+[[package]]
 category = "main"
 description = "User session management for Flask"
 name = "flask-login"
@@ -1921,7 +1932,7 @@ test = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 
 [metadata]
-content-hash = "4635e1ec37a2b4a72ce735b4854ee7f9edeb44187815934b30bcdfc650e303e8"
+content-hash = "2725d4adb82b36319bde09b3c19ddf9b8f9f374df35026e4badfb41a6c5489a9"
 lock-version = "1.0"
 python-versions = "^3.7"
 
@@ -2235,6 +2246,9 @@ flask-cors = [
 flask-executor = [
     {file = "Flask-Executor-0.9.3.tar.gz", hash = "sha256:a36ae8304f0f26c7b0b5341c9faf8e524c4035fb14b5100302400fed1245cec2"},
     {file = "Flask_Executor-0.9.3-py3-none-any.whl", hash = "sha256:31a3a04bc2e4828ee3b6bd58aba6939c0aeec94ddab455ccc76993d20b281bb1"},
+]
+flask-lambda-python36 = [
+    {file = "flask_lambda_python36-0.1.0-py36-none-any.whl", hash = "sha256:d7a7ccef0ea6a2bc68d3a589bd7e8a58cff7dccfc8818cf06f40b4dedfb20552"},
 ]
 flask-login = [
     {file = "Flask-Login-0.5.0.tar.gz", hash = "sha256:6d33aef15b5bcead780acc339464aae8a6e28f13c90d8b1cf9de8b549d1c0b4b"},

--- a/apps/node/pyproject.toml
+++ b/apps/node/pyproject.toml
@@ -43,6 +43,7 @@ flake8 = "^3.8.3"
 flake8-comprehensions = "^3.2.3"
 papermill = "~=2.0.0"
 jupyter = "~=1.0.0"
+flask-lambda-python36 = "~=0.1.0"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
## Description
Integration test are failing because a new dependency `flask-lambda-python36` is required in network app.

The problem is that integrations tests uses `poetry` from node app, not from network app because normally all dependencies required by network already exist in node (but this is not the case)

It is simply fixed adding flask-lambda-python36 as a dev dependency in node-app


## Affected Dependencies
see description

## How has this been tested?
I have run all the test locally

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
