### PR TITLE
add request id for identification

### DIFF
--- a/apps/node/src/app/main/core/codes.py
+++ b/apps/node/src/app/main/core/codes.py
@@ -1,4 +1,5 @@
 class MSG_FIELD:
+    REQUEST_ID = "request_id"
     TYPE = "type"
     DATA = "data"
     WORKER_ID = "worker_id"

--- a/apps/node/src/app/main/events/model_centric/fl_events.py
+++ b/apps/node/src/app/main/events/model_centric/fl_events.py
@@ -138,6 +138,7 @@ def authenticate(message: dict, socket=None) -> str:
         response : String response to the client
     """
     data = message.get("data")
+    request_id = message.get("request_id")
     response = {}
 
     try:
@@ -161,6 +162,7 @@ def authenticate(message: dict, socket=None) -> str:
 
     response = {
         MSG_FIELD.TYPE: MODEL_CENTRIC_FL_EVENTS.AUTHENTICATE,
+        MSG_FIELD.REQUEST_ID: request_id, 
         MSG_FIELD.DATA: response,
     }
     return json.dumps(response)
@@ -177,6 +179,7 @@ def cycle_request(message: dict, socket=None) -> str:
         response : String response to the client
     """
     data = message[MSG_FIELD.DATA]
+    request_id = message[MSG_FIELD.REQUEST_ID]
     response = {}
 
     try:
@@ -229,6 +232,7 @@ def cycle_request(message: dict, socket=None) -> str:
 
     response = {
         MSG_FIELD.TYPE: MODEL_CENTRIC_FL_EVENTS.CYCLE_REQUEST,
+        MSG_FIELD.REQUEST_ID: request_id,
         MSG_FIELD.DATA: response,
     }
     return json.dumps(response)
@@ -246,6 +250,7 @@ def report(message: dict, socket=None) -> str:
         response : String response to the client
     """
     data = message[MSG_FIELD.DATA]
+    request_id = message[MSG_FIELD.REQUEST_ID]
     response = {}
 
     try:
@@ -266,6 +271,7 @@ def report(message: dict, socket=None) -> str:
 
     response = {
         MSG_FIELD.TYPE: MODEL_CENTRIC_FL_EVENTS.REPORT,
+        MSG_FIELD.REQUEST_ID: request_id,
         MSG_FIELD.DATA: response,
     }
     return json.dumps(response)

--- a/apps/node/src/app/main/events/model_centric/fl_events.py
+++ b/apps/node/src/app/main/events/model_centric/fl_events.py
@@ -162,7 +162,7 @@ def authenticate(message: dict, socket=None) -> str:
 
     response = {
         MSG_FIELD.TYPE: MODEL_CENTRIC_FL_EVENTS.AUTHENTICATE,
-        MSG_FIELD.REQUEST_ID: request_id, 
+        MSG_FIELD.REQUEST_ID: request_id,
         MSG_FIELD.DATA: response,
     }
     return json.dumps(response)

--- a/apps/node/src/app/main/model_centric/controller/fl_controller.py
+++ b/apps/node/src/app/main/model_centric/controller/fl_controller.py
@@ -162,9 +162,7 @@ class FLController:
 
             _max_cycles = server_config["num_cycles"]
 
-            response = {
-                CYCLE.STATUS: "rejected"
-            }
+            response = {CYCLE.STATUS: "rejected"}
 
             # If it's not the last cycle, add the remaining time to the next cycle.
             if n_completed_cycles < _max_cycles:

--- a/apps/node/src/app/main/model_centric/controller/fl_controller.py
+++ b/apps/node/src/app/main/model_centric/controller/fl_controller.py
@@ -163,9 +163,7 @@ class FLController:
             _max_cycles = server_config["num_cycles"]
 
             response = {
-                CYCLE.STATUS: "rejected",
-                MSG_FIELD.MODEL: name,
-                CYCLE.VERSION: _cycle.version,
+                CYCLE.STATUS: "rejected"
             }
 
             # If it's not the last cycle, add the remaining time to the next cycle.

--- a/tests/model_centric/test_fl_process.py
+++ b/tests/model_centric/test_fl_process.py
@@ -1,6 +1,6 @@
 import binascii
 import json
-from uuid import UUID
+from uuid import uuid4
 
 import aiounittest
 import pytest
@@ -161,7 +161,9 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
         """ 2 - Authentication Request """
 
         # "model-centric/authenticate" request body
+        request_id = uuid4()
         auth_msg = {
+            "request_id": request_id,
             "type": "model-centric/authenticate",
             "data": {"model_name": "my-federated-model", "model_version": "0.1.0"},
         }
@@ -172,6 +174,7 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
             response["data"]["error"],
             "Authentication is required, please pass an 'auth_token'.",
         )
+        self.assertEqual(response["request_id"], request_id)
         worker_id = response["data"].get("worker_id", None)
         self.assertIsNone(worker_id)
 
@@ -181,6 +184,7 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
         self.assertEqual(
             response["data"]["error"], "The 'auth_token' you sent is invalid."
         )
+        self.assertEqual(response["request_id"], request_id)
         worker_id = response["data"].get("worker_id", None)
         self.assertIsNone(worker_id)
 
@@ -190,6 +194,7 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
         ] = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.yYhP2xosmpuyV5aoT8mz7GFESzq3hKSy-CRWC-vYOIU"
         response = await send_ws_message(auth_msg)
         self.assertEqual(response["data"]["status"], "success")
+        self.assertEqual(response["request_id"], request_id)
         worker_id = response["data"].get("worker_id", None)
         self.assertIsNotNone(worker_id)
 
@@ -199,6 +204,7 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
         ] = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.e30.jOleZNk89aGMWhWVpV8UYul94y7rxBJAg4HnhY72y-DrLfxfhnR8b31FOMUcngxcw-N4MaSz5fulYFSTBt9NwIWWDUeAo0MqNMK-M6RRoxYd35k8SHNTIRAk0KnybKHMnTC4Qay3plXcu3FfMpOkX8Relpb8SUO3T1_B6RFqgNPO_l4KlmtXnxXgeFC86qF8b7fFCo8U1UKVUEbqw4JUCW5OmDnSmGxmb9felzASzuM5sO5MOkksuQ0DGVoi6AadhXQ5zB7k2Mj4fjJH7XyauHeuB2xjNM0jhoeR_DAoztvVEW5qx9fu2JfOiM6ZsBguCL7uKg1h1bQq278btHROpA"
         response = await send_ws_message(auth_msg)
         self.assertEqual(response["data"]["status"], "success")
+        self.assertEqual(response["request_id"], request_id)
         worker_id = response["data"].get("worker_id", None)
         self.assertIsNotNone(worker_id)
 
@@ -213,11 +219,17 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
             "upload": 23.7,
         }
 
-        message = {"type": "model-centric/cycle-request", "data": req_cycle_msg}
+        request_id = uuid4()
+        message = {
+            "type": "model-centric/cycle-request",
+            "request_id": request_id,
+            "data": req_cycle_msg,
+        }
 
         # Send worker authentication message
         response = await send_ws_message(message)
         self.assertEqual(response["data"]["status"], "accepted")
+        self.assertEqual(response["request_id"], request_id)
 
         response_fields = [
             "request_key",
@@ -269,9 +281,10 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
 
         # Send host_training message
         await send_ws_message(host_training_message)
-
+        request_id = uuid4()
         auth_msg = {
             "type": "model-centric/authenticate",
+            "request_id": request_id,
             "data": {"model_name": "my-federated-model-2", "model_version": "0.1.0"},
         }
 
@@ -281,11 +294,14 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
         requires_speed_test = response["data"].get("requires_speed_test")
 
         self.assertIsNotNone(worker_id)
+        self.assertEqual(response["request_id"], request_id)
         self.assertTrue(requires_speed_test)
 
         # Speed must be required in cycle-request
+        request_id = uuid4()
         cycle_req = {
             "type": "model-centric/cycle-request",
+            "request_id": request_id,
             "data": {
                 "worker_id": worker_id,
                 "model": "my-federated-model-2",
@@ -294,11 +310,14 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
         }
         response = await send_ws_message(cycle_req)
         self.assertIsNotNone(response["data"].get("error"))
+        self.assertEqual(response["request_id"], request_id)
         self.assertEqual(response["data"].get("status"), "rejected")
 
         # Should accept into cycle if all speed fields are sent
+        request_id = uuid4()
         cycle_req = {
             "type": "model-centric/cycle-request",
+            "request_id": request_id,
             "data": {
                 "worker_id": worker_id,
                 "model": "my-federated-model-2",
@@ -310,6 +329,7 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
         }
         response = await send_ws_message(cycle_req)
         self.assertIsNone(response["data"].get("error"))
+        self.assertEqual(response["request_id"], request_id)
         self.assertEqual(response["data"].get("status"), "accepted")
 
     async def test_requires_speed_test_false(self):
@@ -347,9 +367,10 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
 
         # Send host_training message
         await send_ws_message(host_training_message)
-
+        request_id = uuid4()
         auth_msg = {
-            "type": "model-centric/authenticate",
+            "type": "model-c|entric/authenticate",
+            "request_id": request_id,
             "data": {"model_name": "my-federated-model-3", "model_version": "0.1.0"},
         }
 
@@ -360,10 +381,13 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
 
         self.assertIsNotNone(worker_id)
         self.assertFalse(requires_speed_test)
+        self.assertEqual(response["request_id"], request_id)
 
         # Speed is not required in cycle-request
+        request_id = uuid4()
         cycle_req = {
             "type": "model-centric/cycle-request",
+            "request_id": request_id,
             "data": {
                 "worker_id": worker_id,
                 "model": "my-federated-model-3",
@@ -372,4 +396,5 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
         }
         response = await send_ws_message(cycle_req)
         self.assertIsNone(response["data"].get("error"))
+        self.assertEqual(response["request_id"], request_id)
         self.assertEqual(response["data"].get("status"), "accepted")

--- a/tests/model_centric/test_fl_process.py
+++ b/tests/model_centric/test_fl_process.py
@@ -369,13 +369,12 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
         await send_ws_message(host_training_message)
         request_id = str(uuid4())
         auth_msg = {
-            "type": "model-c|entric/authenticate",
+            "type": "model-centric/authenticate",
             "request_id": request_id,
             "data": {"model_name": "my-federated-model-3", "model_version": "0.1.0"},
         }
 
         response = await send_ws_message(auth_msg)
-
         worker_id = response["data"].get("worker_id", None)
         requires_speed_test = response["data"].get("requires_speed_test")
 

--- a/tests/model_centric/test_fl_process.py
+++ b/tests/model_centric/test_fl_process.py
@@ -161,7 +161,7 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
         """ 2 - Authentication Request """
 
         # "model-centric/authenticate" request body
-        request_id = uuid4()
+        request_id = str(uuid4())
         auth_msg = {
             "request_id": request_id,
             "type": "model-centric/authenticate",
@@ -219,7 +219,7 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
             "upload": 23.7,
         }
 
-        request_id = uuid4()
+        request_id = str(uuid4())
         message = {
             "type": "model-centric/cycle-request",
             "request_id": request_id,
@@ -281,7 +281,7 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
 
         # Send host_training message
         await send_ws_message(host_training_message)
-        request_id = uuid4()
+        request_id = str(uuid4())
         auth_msg = {
             "type": "model-centric/authenticate",
             "request_id": request_id,
@@ -298,7 +298,7 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
         self.assertTrue(requires_speed_test)
 
         # Speed must be required in cycle-request
-        request_id = uuid4()
+        request_id = str(uuid4())
         cycle_req = {
             "type": "model-centric/cycle-request",
             "request_id": request_id,
@@ -314,7 +314,7 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
         self.assertEqual(response["data"].get("status"), "rejected")
 
         # Should accept into cycle if all speed fields are sent
-        request_id = uuid4()
+        request_id = str(uuid4())
         cycle_req = {
             "type": "model-centric/cycle-request",
             "request_id": request_id,
@@ -367,7 +367,7 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
 
         # Send host_training message
         await send_ws_message(host_training_message)
-        request_id = uuid4()
+        request_id = str(uuid4())
         auth_msg = {
             "type": "model-c|entric/authenticate",
             "request_id": request_id,
@@ -384,7 +384,7 @@ riWYMKALI61uc+NH0jr+B5/XTV/KlNqmbuEWfZdgRcXodNmIXt+LGHOQ1C+X+7OY
         self.assertEqual(response["request_id"], request_id)
 
         # Speed is not required in cycle-request
-        request_id = uuid4()
+        request_id = str(uuid4())
         cycle_req = {
             "type": "model-centric/cycle-request",
             "request_id": request_id,


### PR DESCRIPTION
## Description
implements request id for each socket request for identification and binning at workers. Closes #685 

## Affected Dependencies
fl_controller, fl_events

## How has this been tested?
- tests
- notebook deployment

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
