### PR TITLE
Change "can_manage_roles" to "can_manage_nodes" in Network

### DIFF
--- a/apps/network/src/app/__init__.py
+++ b/apps/network/src/app/__init__.py
@@ -73,7 +73,7 @@ def seed_db():
         can_edit_settings=False,
         can_create_users=False,
         can_edit_roles=False,
-        can_manage_roles=False,
+        can_manage_nodes=False,
     )
     db.session.add(new_user)
     new_user = Role(
@@ -81,7 +81,7 @@ def seed_db():
         can_edit_settings=True,
         can_create_users=True,
         can_edit_roles=True,
-        can_manage_roles=True,
+        can_manage_nodes=True,
     )
     db.session.add(new_user)
 

--- a/apps/network/src/app/users/role.py
+++ b/apps/network/src/app/users/role.py
@@ -9,7 +9,7 @@ class Role(db.Model):
     can_edit_settings = db.Column(db.Boolean())
     can_create_users = db.Column(db.Boolean())
     can_edit_roles = db.Column(db.Boolean())
-    can_manage_roles = db.Column(db.Boolean())
+    can_manage_nodes = db.Column(db.Boolean())
 
     def __str__(self):
         return (
@@ -17,5 +17,5 @@ class Role(db.Model):
             f"can_edit_settings: {self.can_edit_settings}, "
             f"can_create_users: {self.can_create_users}, "
             f"can_edit_roles: {self.can_edit_roles}, "
-            f"can_manage_roles: {self.can_manage_roles}>"
+            f"can_manage_nodes: {self.can_manage_nodes}>"
         )

--- a/apps/network/tests/database/test_role.py
+++ b/apps/network/tests/database/test_role.py
@@ -5,7 +5,7 @@ from .presets.role import role_metrics
 
 
 @pytest.mark.parametrize(
-    ("name, can_edit_settings, can_create_users," "can_edit_roles, can_manage_roles"),
+    ("name, can_edit_settings, can_create_users," "can_edit_roles, can_manage_nodes"),
     role_metrics,
 )
 def test_create_role_object(
@@ -13,7 +13,7 @@ def test_create_role_object(
     can_edit_settings,
     can_create_users,
     can_edit_roles,
-    can_manage_roles,
+    can_manage_nodes,
     database,
 ):
     role = Role(
@@ -21,7 +21,7 @@ def test_create_role_object(
         can_edit_settings=can_edit_settings,
         can_create_users=can_create_users,
         can_edit_roles=can_edit_roles,
-        can_manage_roles=can_manage_roles,
+        can_manage_nodes=can_manage_nodes,
     )
     database.session.add(role)
     database.session.commit()


### PR DESCRIPTION
## Description
There was a typo in the original issue for seeding the roles of a Network. There are two fields which are similar: `can_edit_roles` and `can_manage_roles`. Instead, `can_manage_roles` should be `can_manage_nodes`.

Fixes #723 

## Affected Dependencies
 - None

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
