### PR TITLE
Create Node API endpoints for Groups

### DIFF
--- a/apps/node/src/app/main/core/codes.py
+++ b/apps/node/src/app/main/core/codes.py
@@ -55,6 +55,14 @@ class ROLE_EVENTS(object):
     DELETE_ROLE = "delete-role"
 
 
+class GROUP_EVENTS(object):
+    CREATE_GROUP = "create-group"
+    GET_GROUP = "get-group"
+    GET_ALL_GROUPS = "get-all-groups"
+    PUT_GROUP = "put-group"
+    DELETE_GROUP = "delete-group"
+
+
 class CYCLE(object):
     STATUS = "status"
     KEY = "request_key"

--- a/apps/node/src/app/main/events/__init__.py
+++ b/apps/node/src/app/main/events/__init__.py
@@ -7,7 +7,7 @@ from syft.codes import REQUEST_MSG
 
 from .. import ws
 from ..core.codes import *
-from ..core.codes import USER_EVENTS, ROLE_EVENTS
+from ..core.codes import USER_EVENTS, ROLE_EVENTS, GROUP_EVENTS
 from .data_centric.control_events import *
 from .data_centric.model_events import *
 from .data_centric.syft_events import *
@@ -16,6 +16,7 @@ from .model_centric.fl_events import *
 from .socket_handler import SocketHandler
 from .user_related import *
 from .role_related import *
+from .group_related import *
 
 # Websocket events routes
 # This structure allows compatibility between javascript applications (syft.js/grid.js) and PyGrid.
@@ -40,6 +41,11 @@ routes = {
     ROLE_EVENTS.GET_ALL_ROLES: get_all_roles_socket,
     ROLE_EVENTS.PUT_ROLE: put_role_socket,
     ROLE_EVENTS.DELETE_ROLE: delete_role_socket,
+    GROUP_EVENTS.CREATE_GROUP: create_group_socket,
+    GROUP_EVENTS.GET_GROUP: get_group_socket,
+    GROUP_EVENTS.GET_ALL_GROUPS: get_all_groups_socket,
+    GROUP_EVENTS.PUT_GROUP: put_group_socket,
+    GROUP_EVENTS.DELETE_GROUP: delete_group_socket,
     REQUEST_MSG.GET_ID: get_node_infos,
     REQUEST_MSG.CONNECT_NODE: connect_grid_nodes,
     REQUEST_MSG.HOST_MODEL: host_model,

--- a/apps/node/src/app/main/events/group_related.py
+++ b/apps/node/src/app/main/events/group_related.py
@@ -1,0 +1,154 @@
+from datetime import datetime, timedelta
+from json import dumps, loads
+from json.decoder import JSONDecodeError
+from secrets import token_hex
+
+import jwt
+from bcrypt import checkpw, gensalt, hashpw
+from flask import Response
+from flask import current_app as app
+from flask import request
+from syft.codes import RESPONSE_MSG
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from ... import db
+from ..auth import error_handler, token_required_factory
+from ..core.exceptions import (
+    AuthorizationError,
+    GroupNotFoundError,
+    InvalidCredentialsError,
+    MissingRequestKeyError,
+    PyGridError,
+    RoleNotFoundError,
+    UserNotFoundError,
+)
+from ..database import Group, Role, User, UserGroup
+from ..database.utils import *
+from ..users.group_ops import (
+    create_group,
+    get_group,
+    get_all_groups,
+    put_group,
+    delete_group,
+)
+
+
+def get_token(*args, **kwargs):
+    message = args[0]
+    token = message.get("token")
+    if token is None:
+        raise MissingRequestKeyError
+
+    return token
+
+
+def format_result(response_body, status_code, mimetype):
+    return dumps(response_body)
+
+
+token_required = token_required_factory(get_token, format_result)
+
+
+@token_required
+def create_group_socket(current_user: User, message: dict) -> str:
+    def route_logic(current_user: User, message: dict) -> dict:
+        name = message.get("name")
+        private_key = message.get("private-key")
+
+        if name is None or private_key is None:
+            raise MissingRequestKeyError
+        if private_key != current_user.private_key:
+            raise InvalidCredentialsError
+
+        group = create_group(current_user, private_key, name)
+        group = model_to_json(group)
+        response_body = {RESPONSE_MSG.SUCCESS: True, "group": group}
+        return response_body
+
+    status_code, response_body = error_handler(route_logic, current_user, message)
+
+    return dumps(response_body)
+
+
+@token_required
+def get_group_socket(current_user: User, message: dict) -> str:
+    def route_logic(current_user: User, message: dict) -> dict:
+        group_id = message.get("id")
+        private_key = message.get("private-key")
+
+        if private_key is None:
+            raise MissingRequestKeyError
+        if private_key != current_user.private_key:
+            raise InvalidCredentialsError
+
+        group = get_group(current_user, private_key, group_id)
+        group = model_to_json(group)
+        response_body = {RESPONSE_MSG.SUCCESS: True, "group": group}
+        return response_body
+
+    status_code, response_body = error_handler(route_logic, current_user, message)
+
+    return dumps(response_body)
+
+
+@token_required
+def get_all_groups_socket(current_user: User, message: dict) -> str:
+    def route_logic(current_user: User, message: dict) -> dict:
+        private_key = message.get("private-key")
+
+        if private_key is None:
+            raise MissingRequestKeyError
+        if private_key != current_user.private_key:
+            raise InvalidCredentialsError
+
+        groups = get_all_groups(current_user, private_key)
+        groups = [model_to_json(group) for group in groups]
+        response_body = {RESPONSE_MSG.SUCCESS: True, "groups": groups}
+        return response_body
+
+    status_code, response_body = error_handler(route_logic, current_user, message)
+
+    return dumps(response_body)
+
+
+@token_required
+def put_group_socket(current_user: User, message: dict) -> str:
+    def route_logic(current_user: User, message: dict) -> dict:
+        private_key = message.get("private-key")
+        new_group = message.get("group")
+        group_id = message.get("id")
+
+        if new_group is None or private_key is None:
+            raise MissingRequestKeyError
+        if private_key != current_user.private_key:
+            raise InvalidCredentialsError
+
+        group = put_group(current_user, private_key, group_id, new_group)
+        group = model_to_json(group)
+        response_body = {RESPONSE_MSG.SUCCESS: True, "group": group}
+        return response_body
+
+    status_code, response_body = error_handler(route_logic, current_user, message)
+
+    return dumps(response_body)
+
+
+@token_required
+def delete_group_socket(current_user: User, message: dict) -> str:
+    def route_logic(current_user: User, message: dict) -> dict:
+        group_id = message.get("id")
+        private_key = message.get("private-key")
+
+        if private_key is None:
+            raise MissingRequestKeyError
+        if private_key != current_user.private_key:
+            raise InvalidCredentialsError
+
+        group = delete_group(current_user, private_key, group_id)
+        group = model_to_json(group)
+        response_body = {RESPONSE_MSG.SUCCESS: True, "group": group}
+        return response_body
+
+    status_code, response_body = error_handler(route_logic, current_user, message)
+
+    return dumps(response_body)

--- a/apps/node/src/app/main/routes/__init__.py
+++ b/apps/node/src/app/main/routes/__init__.py
@@ -3,3 +3,4 @@ from .general import *
 from .model_centric.routes import *
 from .user_related import *
 from .role_related import *
+from .group_related import *

--- a/apps/node/src/app/main/routes/group_related.py
+++ b/apps/node/src/app/main/routes/group_related.py
@@ -1,0 +1,171 @@
+from datetime import datetime, timedelta
+from json import dumps, loads
+from json.decoder import JSONDecodeError
+from secrets import token_hex
+
+import jwt
+from bcrypt import checkpw, gensalt, hashpw
+from flask import Response
+from flask import current_app as app
+from flask import request
+from syft.codes import RESPONSE_MSG
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from ... import db
+from .. import main_routes
+from ..auth import error_handler, token_required_factory
+from ..core.exceptions import (
+    AuthorizationError,
+    GroupNotFoundError,
+    InvalidCredentialsError,
+    MissingRequestKeyError,
+    PyGridError,
+    RoleNotFoundError,
+    UserNotFoundError,
+)
+from ..database import Group, Role, User, UserGroup
+from ..database.utils import *
+from ..users.group_ops import (
+    create_group,
+    get_group,
+    get_all_groups,
+    put_group,
+    delete_group,
+)
+
+expected_fields = "name"
+
+
+def get_token(*args, **kwargs):
+    token = request.headers.get("token")
+    if token is None:
+        raise MissingRequestKeyError
+
+    return token
+
+
+def format_result(response_body, status_code, mimetype):
+    return Response(dumps(response_body), status=status_code, mimetype=mimetype)
+
+
+token_required = token_required_factory(get_token, format_result)
+
+
+@main_routes.route("/groups", methods=["POST"])
+@token_required
+def create_group_route(current_user):
+    def route_logic(current_user):
+        data = loads(request.data)
+        name = data.get("name")
+
+        private_key = request.headers.get("private-key")
+
+        if name is None or private_key is None:
+            raise MissingRequestKeyError
+        if private_key != current_user.private_key:
+            raise InvalidCredentialsError
+
+        group = create_group(current_user, private_key, name)
+        group = model_to_json(group)
+        response_body = {RESPONSE_MSG.SUCCESS: True, "group": group}
+        return response_body
+
+    status_code, response_body = error_handler(route_logic, current_user)
+
+    return Response(
+        dumps(response_body), status=status_code, mimetype="application/json"
+    )
+
+
+@main_routes.route("/groups/<group_id>", methods=["GET"])
+@token_required
+def get_group_route(current_user, group_id):
+    def route_logic(current_user, group_id):
+        group_id = int(group_id)
+        private_key = request.headers.get("private-key")
+
+        if private_key is None:
+            raise MissingRequestKeyError
+        if private_key != current_user.private_key:
+            raise InvalidCredentialsError
+
+        group = get_group(current_user, private_key, group_id)
+        group = model_to_json(group)
+        response_body = {RESPONSE_MSG.SUCCESS: True, "group": group}
+        return response_body
+
+    status_code, response_body = error_handler(route_logic, current_user, group_id)
+
+    return Response(
+        dumps(response_body), status=status_code, mimetype="application/json"
+    )
+
+
+@main_routes.route("/groups", methods=["GET"])
+@token_required
+def get_all_groups_route(current_user):
+    def route_logic(current_user):
+        private_key = request.headers.get("private-key")
+
+        if private_key is None:
+            raise MissingRequestKeyError
+        if private_key != current_user.private_key:
+            raise InvalidCredentialsError
+
+        groups = get_all_groups(current_user, private_key)
+        groups = [model_to_json(group) for group in groups]
+        response_body = {RESPONSE_MSG.SUCCESS: True, "groups": groups}
+        return response_body
+
+    status_code, response_body = error_handler(route_logic, current_user)
+
+    return Response(
+        dumps(response_body), status=status_code, mimetype="application/json"
+    )
+
+
+@main_routes.route("/groups/<group_id>", methods=["PUT"])
+@token_required
+def update_group_route(current_user, group_id):
+    def route_logic(current_user, group_id):
+        private_key = request.headers.get("private-key")
+        new_fields = loads(request.data)
+
+        if private_key is None:
+            raise MissingRequestKeyError
+        if private_key != current_user.private_key:
+            raise InvalidCredentialsError
+
+        group = put_group(current_user, private_key, group_id, new_fields)
+        group = model_to_json(group)
+        response_body = {RESPONSE_MSG.SUCCESS: True, "group": group}
+        return response_body
+
+    status_code, response_body = error_handler(route_logic, current_user, group_id)
+
+    return Response(
+        dumps(response_body), status=status_code, mimetype="application/json"
+    )
+
+
+@main_routes.route("/groups/<group_id>", methods=["DELETE"])
+@token_required
+def delete_group_route(current_user, group_id):
+    def route_logic(current_user, group_id):
+        private_key = request.headers.get("private-key")
+
+        if private_key is None:
+            raise MissingRequestKeyError
+        if private_key != current_user.private_key:
+            raise InvalidCredentialsError
+
+        group = delete_group(current_user, private_key, group_id)
+        group = model_to_json(group)
+        response_body = {RESPONSE_MSG.SUCCESS: True, "group": group}
+        return response_body
+
+    status_code, response_body = error_handler(route_logic, current_user, group_id)
+
+    return Response(
+        dumps(response_body), status=status_code, mimetype="application/json"
+    )

--- a/apps/node/src/app/main/users/group_ops.py
+++ b/apps/node/src/app/main/users/group_ops.py
@@ -1,0 +1,120 @@
+import logging
+from datetime import datetime, timedelta
+from json import dumps, loads
+from json.decoder import JSONDecodeError
+from secrets import token_hex
+
+import jwt
+from bcrypt import checkpw, gensalt, hashpw
+from flask import Response
+from flask import current_app as app
+from flask import request
+from syft.codes import RESPONSE_MSG
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from ... import db
+from .. import main_routes
+from ..core.exceptions import (
+    AuthorizationError,
+    GroupNotFoundError,
+    InvalidCredentialsError,
+    MissingRequestKeyError,
+    PyGridError,
+    RoleNotFoundError,
+    UserNotFoundError,
+)
+from ..database import Group, Role, User, UserGroup
+
+
+def identify_user(private_key):
+    if private_key is None:
+        raise MissingRequestKeyError
+
+    user = db.session.query(User).filter_by(private_key=private_key).one_or_none()
+    if user is None:
+        raise UserNotFoundError
+
+    user_role = db.session.query(Role).get(user.role)
+    if user_role is None:
+        raise RoleNotFoundError
+
+    return user, user_role
+
+
+def create_group(current_user, private_key, name):
+    user_role = Role.query.get(current_user.role)
+    if user_role is None:
+        raise RoleNotFoundError
+
+    if not user_role.can_create_groups:
+        raise AuthorizationError
+
+    new_group = Group(name=name)
+    db.session.add(new_group)
+    db.session.commit()
+    return new_group
+
+
+def get_group(current_user, private_key, group_id):
+    user_role = Role.query.get(current_user.role)
+    if user_role is None:
+        raise RoleNotFoundError
+
+    if not user_role.can_triage_requests:
+        raise AuthorizationError
+
+    group = Group.query.get(group_id)
+    if group is None:
+        raise GroupNotFoundError
+
+    return group
+
+
+def get_all_groups(current_user, private_key):
+    user_role = Role.query.get(current_user.role)
+    if user_role is None:
+        raise RoleNotFoundError
+
+    if not user_role.can_triage_requests:
+        raise AuthorizationError
+
+    groups = Group.query.all()
+
+    return groups
+
+
+def put_group(current_user, private_key, group_id, new_fields):
+    user_role = db.session.query(Role).get(current_user.role)
+
+    if user_role is None:
+        raise RoleNotFoundError
+    if not user_role.can_create_groups:
+        raise AuthorizationError
+
+    group = db.session.query(Group).get(group_id)
+    if group is None:
+        raise GroupNotFoundError
+
+    for key, value in new_fields.items():
+        setattr(group, key, value)
+
+    db.session.commit()
+    return group
+
+
+def delete_group(current_user, private_key, group_id):
+    user_role = db.session.query(Role).get(current_user.role)
+
+    if user_role is None:
+        raise RoleNotFoundError
+    if not user_role.can_create_groups:
+        raise AuthorizationError
+
+    group = db.session.query(Group).get(group_id)
+    if group is None:
+        raise GroupNotFoundError
+
+    db.session.delete(group)
+    db.session.commit()
+
+    return group

--- a/apps/node/src/app/main/users/role_ops.py
+++ b/apps/node/src/app/main/users/role_ops.py
@@ -85,8 +85,6 @@ def delete_role(current_user, role_id):
         raise RoleNotFoundError
     if not user_role.can_edit_roles:
         raise AuthorizationError
-    if not user_role.can_edit_roles:
-        raise AuthorizationError
 
     role = db.session.query(Role).get(role_id)
     if role is None:

--- a/apps/node/tests/rest_api/users/test_groups_http.py
+++ b/apps/node/tests/rest_api/users/test_groups_http.py
@@ -1,0 +1,869 @@
+from json import dumps, loads
+
+import jwt
+import pytest
+from flask import current_app as app
+from src.app.main.database import *
+
+JSON_DECODE_ERR_MSG = (
+    "Expecting property name enclosed in " "double quotes: line 1 column 2 (char 1)"
+)
+owner_role = ("Owner", True, True, True, True, True, True, True)
+user_role = ("User", False, False, False, False, False, False, False)
+admin_role = ("Administrator", True, True, True, True, False, False, True)
+
+user1 = (
+    "tech@gibberish.com",
+    "BDEB6E8EE39B6C70835993486C9E65DC",
+    "]GBF[R>GX[9Cmk@DthFT!mhloUc%[f",
+    "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+    1,
+)
+user2 = (
+    "anemail@anemail.com",
+    "2amt5MXKdLhEEL8FiQLcl8Mp0FNhZI6",
+    "$2b$12$rj8MnLcKBxAgL7GUHrYn6O",
+    "acfc10d15d7ec9f7cd05a312489af2794619c6f11e9af34671a5f33da48c1de2",
+    2,
+)
+user3 = (
+    "anemail@anemail.com",
+    "2amt5MXKdLhEEL8FiQLcl8Mp0FNhZI6",
+    "$2b$12$rj8MnLcKBxAgL7GUHrYn6O",
+    "acfc10d15d7ec9f7cd05a312489af2794619c6f11e9af34671a5f33da48c1de2",
+    3,
+)
+user4 = (
+    "tech@gibberish.com",
+    "2amt5MXKdLhEEL8FiQLcl8Mp0FNhZI6",
+    "$2b$12$tufn64/0gSIAdprqBrRzC.",
+    "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+    2,
+)
+
+
+@pytest.fixture
+def cleanup(database):
+    yield
+    try:
+        database.session.query(User).delete()
+        database.session.query(Role).delete()
+        database.session.query(Group).delete()
+        database.session.query(UserGroup).delete()
+        database.session.commit()
+    except:
+        database.session.rollback()
+
+
+# CREATE GROUP
+
+
+def test_create_group_success(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    payload = {"name": "Hospital X"}
+    result = client.post(
+        "/groups", data=dumps(payload), headers=headers, content_type="application/json"
+    )
+
+    assert result.status_code == 200
+    assert result.get_json()["group"]["id"] == 1
+    assert result.get_json()["group"]["name"] == "Hospital X"
+
+
+def test_create_group_missing_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_role = create_role(*user_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_user = create_user(*user2)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {"token": token.decode("UTF-8")}
+    payload = {"name": "Hospital X"}
+    result = client.post(
+        "/groups", data=dumps(payload), headers=headers, content_type="application/json"
+    )
+
+    assert result.status_code == 400
+    assert result.get_json()["error"] == "Missing request key!"
+
+
+def test_create_group_missing_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_role = create_role(*user_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_user = create_user(*user2)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced"
+    }
+    payload = {"name": "Hospital X"}
+    result = client.post(
+        "/groups", data=dumps(payload), headers=headers, content_type="application/json"
+    )
+
+    assert result.status_code == 400
+    assert result.get_json()["error"] == "Missing request key!"
+
+
+def test_create_group_invalid_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_role = create_role(*user_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_user = create_user(*user2)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "invalid312987as12they0come",
+        "token": token.decode("UTF-8"),
+    }
+    payload = {"name": "Hospital X"}
+    result = client.post(
+        "/groups", data=dumps(payload), headers=headers, content_type="application/json"
+    )
+
+    assert result.status_code == 403
+    assert result.get_json()["error"] == "Invalid credentials!"
+
+
+def test_create_group_invalid_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_role = create_role(*user_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_user = create_user(*user2)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, "peppperplsiwouldhavesome")
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    payload = {"name": "Hospital X"}
+    result = client.post(
+        "/groups", data=dumps(payload), headers=headers, content_type="application/json"
+    )
+
+    assert result.status_code == 403
+    assert result.get_json()["error"] == "Invalid credentials!"
+
+
+def test_create_group_unauthorized(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_role = create_role(*user_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_user = create_user(*user2)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 2}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "acfc10d15d7ec9f7cd05a312489af2794619c6f11e9af34671a5f33da48c1de2",
+        "token": token.decode("UTF-8"),
+    }
+    payload = {"name": "Hospital X"}
+    result = client.post(
+        "/groups", data=dumps(payload), headers=headers, content_type="application/json"
+    )
+
+    assert result.status_code == 403
+    assert result.get_json()["error"] == "User is not authorized for this operation!"
+
+
+# GET GROUP
+
+
+def test_get_group_success(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = client.get("/groups/1", headers=headers, content_type="application/json")
+
+    assert result.status_code == 200
+    assert result.get_json()["group"]["id"] == 1
+    assert result.get_json()["group"]["name"] == "Hospital X"
+
+
+def test_get_group_missing_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "token": token.decode("UTF-8"),
+    }
+    result = client.get("/groups/1", headers=headers, content_type="application/json")
+
+    assert result.status_code == 400
+    assert result.get_json()["error"] == "Missing request key!"
+
+
+def test_get_group_missing_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+    }
+    result = client.get("/groups/1", headers=headers, content_type="application/json")
+
+    assert result.status_code == 400
+    assert result.get_json()["error"] == "Missing request key!"
+
+
+def test_get_group_invalid_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "invalid85b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = client.get("/groups/1", headers=headers, content_type="application/json")
+
+    assert result.status_code == 403
+    assert result.get_json()["error"] == "Invalid credentials!"
+
+
+def test_get_group_invalid_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, "thewrongsecret")
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = client.get("/groups/1", headers=headers, content_type="application/json")
+
+    assert result.status_code == 403
+    assert result.get_json()["error"] == "Invalid credentials!"
+
+
+def test_get_group_unauthorized(client, database, cleanup):
+    new_role = create_role(*user_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = client.get("/groups/1", headers=headers, content_type="application/json")
+
+    assert result.status_code == 403
+    assert result.get_json()["error"] == "User is not authorized for this operation!"
+
+
+def test_get_group_missing_group(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = client.get("/groups/1", headers=headers, content_type="application/json")
+
+    assert result.status_code == 404
+    assert result.get_json()["error"] == "Group ID not found!"
+
+
+# GET ALL GROUPS
+
+
+def test_get_all_groups_success(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+    new_group = Group(name="Hospital Y")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = client.get("/groups", headers=headers, content_type="application/json")
+
+    assert result.status_code == 200
+    assert result.get_json()["groups"][0]["id"] == 1
+    assert result.get_json()["groups"][0]["name"] == "Hospital X"
+    assert result.get_json()["groups"][1]["id"] == 2
+    assert result.get_json()["groups"][1]["name"] == "Hospital Y"
+
+
+def test_get_all_groups_empty_success(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = client.get("/groups", headers=headers, content_type="application/json")
+
+    assert result.status_code == 200
+    assert result.get_json()["groups"] == []
+
+
+def test_get_all_groups_missing_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+    new_group = Group(name="Hospital Y")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "token": token.decode("UTF-8"),
+    }
+    result = client.get("/groups", headers=headers, content_type="application/json")
+
+    assert result.status_code == 400
+    assert result.get_json()["error"] == "Missing request key!"
+
+
+def test_get_all_groups_missing_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+    new_group = Group(name="Hospital Y")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+    }
+    result = client.get("/groups", headers=headers, content_type="application/json")
+
+    assert result.status_code == 400
+    assert result.get_json()["error"] == "Missing request key!"
+
+
+def test_get_all_groups_invalid_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+    new_group = Group(name="Hospital Y")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "invalid85b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = client.get("/groups", headers=headers, content_type="application/json")
+
+    assert result.status_code == 403
+    assert result.get_json()["error"] == "Invalid credentials!"
+
+
+def test_get_all_groups_invalid_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+    new_group = Group(name="Hospital Y")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, "thewrongsecret")
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = client.get("/groups", headers=headers, content_type="application/json")
+
+    assert result.status_code == 403
+    assert result.get_json()["error"] == "Invalid credentials!"
+
+
+def test_get_all_groups_unauthorized(client, database, cleanup):
+    new_role = create_role(*user_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+    new_group = Group(name="Hospital Y")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = client.get("/groups", headers=headers, content_type="application/json")
+
+    assert result.status_code == 403
+    assert result.get_json()["error"] == "User is not authorized for this operation!"
+
+
+# PUT GROUP
+
+
+def test_put_group_success(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    new_name = "Brand New Hospital A"
+    payload = {"name": new_name}
+    result = client.put(
+        "/groups/1",
+        headers=headers,
+        data=dumps(payload),
+        content_type="application/json",
+    )
+
+    assert result.status_code == 200
+    assert result.get_json()["group"]["id"] == 1
+    assert result.get_json()["group"]["name"] == new_name
+    assert database.session.query(Group).get(1).name == new_name
+
+
+def test_put_group_missing_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "token": token.decode("UTF-8"),
+    }
+    new_name = "Brand New Hospital A"
+    payload = {"name": new_name}
+    result = client.put(
+        "/groups/1",
+        headers=headers,
+        data=dumps(payload),
+        content_type="application/json",
+    )
+
+    assert result.status_code == 400
+    assert result.get_json()["error"] == "Missing request key!"
+
+
+def test_put_group_missing_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+    }
+    new_name = "Brand New Hospital A"
+    payload = {"name": new_name}
+    result = client.put(
+        "/groups/1",
+        headers=headers,
+        data=dumps(payload),
+        content_type="application/json",
+    )
+
+    assert result.status_code == 400
+    assert result.get_json()["error"] == "Missing request key!"
+
+
+def test_put_group_invalid_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "invalid85b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    new_name = "Brand New Hospital A"
+    payload = {"name": new_name}
+    result = client.put(
+        "/groups/1",
+        headers=headers,
+        data=dumps(payload),
+        content_type="application/json",
+    )
+
+    assert result.status_code == 403
+    assert result.get_json()["error"] == "Invalid credentials!"
+
+
+def test_put_group_invalid_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, "thewrongsecret")
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    new_name = "Brand New Hospital A"
+    payload = {"name": new_name}
+    result = client.put(
+        "/groups/1",
+        headers=headers,
+        data=dumps(payload),
+        content_type="application/json",
+    )
+
+    assert result.status_code == 403
+    assert result.get_json()["error"] == "Invalid credentials!"
+
+
+def test_put_group_unauthorized(client, database, cleanup):
+    new_role = create_role(*user_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    new_name = "Brand New Hospital A"
+    payload = {"name": new_name}
+    result = client.put(
+        "/groups/1",
+        headers=headers,
+        data=dumps(payload),
+        content_type="application/json",
+    )
+
+    assert result.status_code == 403
+    assert result.get_json()["error"] == "User is not authorized for this operation!"
+
+
+def test_put_group_missing_group(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    new_name = "Brand New Hospital A"
+    payload = {"name": new_name}
+    result = client.put(
+        "/groups/1",
+        headers=headers,
+        data=dumps(payload),
+        content_type="application/json",
+    )
+
+    assert result.status_code == 404
+    assert result.get_json()["error"] == "Group ID not found!"
+
+
+# DELETE GROUP
+
+
+def test_delete_group_success(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    assert database.session.query(Group).get(1) is not None
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = client.delete(
+        "/groups/1", headers=headers, content_type="application/json",
+    )
+
+    assert result.status_code == 200
+    assert database.session.query(Group).get(1) is None
+
+
+def test_put_group_missing_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "token": token.decode("UTF-8"),
+    }
+    result = client.delete(
+        "/groups/1", headers=headers, content_type="application/json",
+    )
+
+    assert result.status_code == 400
+    assert result.get_json()["error"] == "Missing request key!"
+
+
+def test_put_group_missing_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+    }
+    result = client.delete(
+        "/groups/1", headers=headers, content_type="application/json",
+    )
+
+    assert result.status_code == 400
+    assert result.get_json()["error"] == "Missing request key!"
+
+
+def test_put_group_invalid_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "invalid85b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = client.delete(
+        "/groups/1", headers=headers, content_type="application/json",
+    )
+
+    assert result.status_code == 403
+    assert result.get_json()["error"] == "Invalid credentials!"
+
+
+def test_put_group_invalid_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, "thewrongsecret")
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = client.delete(
+        "/groups/1", headers=headers, content_type="application/json",
+    )
+
+    assert result.status_code == 403
+    assert result.get_json()["error"] == "Invalid credentials!"
+
+
+def test_put_group_unauthorized(client, database, cleanup):
+    new_role = create_role(*user_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = client.delete(
+        "/groups/1", headers=headers, content_type="application/json",
+    )
+
+    assert result.status_code == 403
+    assert result.get_json()["error"] == "User is not authorized for this operation!"
+
+
+def test_put_group_missing_group(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    headers = {
+        "private_key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = client.delete(
+        "/groups/1", headers=headers, content_type="application/json",
+    )
+
+    assert result.status_code == 404
+    assert result.get_json()["error"] == "Group ID not found!"

--- a/apps/node/tests/websocket_api/test_groups_ws.py
+++ b/apps/node/tests/websocket_api/test_groups_ws.py
@@ -1,0 +1,821 @@
+from json import dumps, loads
+
+import jwt
+import pytest
+from flask import current_app as app
+from src.app.main.database import *
+from src.app.main.events.group_related import *
+
+JSON_DECODE_ERR_MSG = (
+    "Expecting property name enclosed in " "double quotes: line 1 column 2 (char 1)"
+)
+owner_role = ("Owner", True, True, True, True, True, True, True)
+user_role = ("User", False, False, False, False, False, False, False)
+admin_role = ("Administrator", True, True, True, True, False, False, True)
+
+user1 = (
+    "tech@gibberish.com",
+    "BDEB6E8EE39B6C70835993486C9E65DC",
+    "]GBF[R>GX[9Cmk@DthFT!mhloUc%[f",
+    "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+    1,
+)
+user2 = (
+    "anemail@anemail.com",
+    "2amt5MXKdLhEEL8FiQLcl8Mp0FNhZI6",
+    "$2b$12$rj8MnLcKBxAgL7GUHrYn6O",
+    "acfc10d15d7ec9f7cd05a312489af2794619c6f11e9af34671a5f33da48c1de2",
+    2,
+)
+user3 = (
+    "anemail@anemail.com",
+    "2amt5MXKdLhEEL8FiQLcl8Mp0FNhZI6",
+    "$2b$12$rj8MnLcKBxAgL7GUHrYn6O",
+    "acfc10d15d7ec9f7cd05a312489af2794619c6f11e9af34671a5f33da48c1de2",
+    3,
+)
+user4 = (
+    "tech@gibberish.com",
+    "2amt5MXKdLhEEL8FiQLcl8Mp0FNhZI6",
+    "$2b$12$tufn64/0gSIAdprqBrRzC.",
+    "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+    2,
+)
+
+
+@pytest.fixture
+def cleanup(database):
+    yield
+    try:
+        database.session.query(User).delete()
+        database.session.query(Role).delete()
+        database.session.query(Group).delete()
+        database.session.query(UserGroup).delete()
+        database.session.commit()
+    except:
+        database.session.rollback()
+
+
+# CREATE GROUP
+
+
+def test_create_group_success(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+        "name": "Hospital X",
+    }
+    result = create_group_socket(message)
+    result = loads(result)
+
+    assert result["group"]["id"] == 1
+    assert result["group"]["name"] == "Hospital X"
+
+
+def test_create_group_missing_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_role = create_role(*user_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_user = create_user(*user2)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {"token": token.decode("UTF-8"), "name": "Hospital X"}
+    result = create_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Missing request key!"
+
+
+def test_create_group_missing_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_role = create_role(*user_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_user = create_user(*user2)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "name": "Hospital X",
+    }
+    result = create_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Missing request key!"
+
+
+def test_create_group_invalid_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_role = create_role(*user_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_user = create_user(*user2)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {
+        "private-key": "invalid312987as12they0come",
+        "token": token.decode("UTF-8"),
+        "name": "Hospital X",
+    }
+    result = create_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Invalid credentials!"
+
+
+def test_create_group_invalid_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_role = create_role(*user_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_user = create_user(*user2)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, "peppperplsiwouldhavesome")
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+        "name": "Hospital X",
+    }
+    result = create_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Invalid credentials!"
+
+
+def test_create_group_unauthorized(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_role = create_role(*user_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_user = create_user(*user2)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 2}, app.config["SECRET_KEY"])
+    message = {
+        "private-key": "acfc10d15d7ec9f7cd05a312489af2794619c6f11e9af34671a5f33da48c1de2",
+        "token": token.decode("UTF-8"),
+        "name": "Hospital X",
+    }
+    result = create_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "User is not authorized for this operation!"
+
+
+# GET GROUP
+
+
+def test_get_group_success(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+        "id": 1,
+    }
+    result = get_group_socket(message)
+    result = loads(result)
+
+    assert result["group"]["id"] == 1
+    assert result["group"]["name"] == "Hospital X"
+
+
+def test_get_group_missing_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {"token": token.decode("UTF-8"), "id": 1}
+    result = get_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Missing request key!"
+
+
+def test_get_group_missing_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "id": 1,
+    }
+    result = get_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Missing request key!"
+
+
+def test_get_group_invalid_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {
+        "private-key": "invalid85b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+        "id": 1,
+    }
+    result = get_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Invalid credentials!"
+
+
+def test_get_group_invalid_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, "thewrongsecret")
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+        "id": 1,
+    }
+    result = get_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Invalid credentials!"
+
+
+def test_get_group_unauthorized(client, database, cleanup):
+    new_role = create_role(*user_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+        "id": 1,
+    }
+    result = get_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "User is not authorized for this operation!"
+
+
+def test_get_group_missing_group(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+        "id": 1,
+    }
+    result = get_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Group ID not found!"
+
+
+# GET ALL GROUPS
+
+
+def test_get_all_groups_success(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+    new_group = Group(name="Hospital Y")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = get_all_groups_socket(message)
+    result = loads(result)
+
+    assert result["groups"][0]["id"] == 1
+    assert result["groups"][0]["name"] == "Hospital X"
+    assert result["groups"][1]["id"] == 2
+    assert result["groups"][1]["name"] == "Hospital Y"
+
+
+def test_get_all_groups_empty_success(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = get_all_groups_socket(message)
+    result = loads(result)
+
+    assert result["groups"] == []
+
+
+def test_get_all_groups_missing_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+    new_group = Group(name="Hospital Y")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {
+        "token": token.decode("UTF-8"),
+    }
+    result = get_all_groups_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Missing request key!"
+
+
+def test_get_all_groups_missing_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+    new_group = Group(name="Hospital Y")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+    }
+    result = get_all_groups_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Missing request key!"
+
+
+def test_get_all_groups_invalid_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+    new_group = Group(name="Hospital Y")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {
+        "private-key": "invalid85b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = get_all_groups_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Invalid credentials!"
+
+
+def test_get_all_groups_invalid_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+    new_group = Group(name="Hospital Y")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, "thewrongsecret")
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = get_all_groups_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Invalid credentials!"
+
+
+def test_get_all_groups_unauthorized(client, database, cleanup):
+    new_role = create_role(*user_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+    new_group = Group(name="Hospital Y")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+    }
+    result = get_all_groups_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "User is not authorized for this operation!"
+
+
+# PUT GROUP
+
+
+def test_put_group_success(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    new_name = "Brand New Hospital A"
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+        "group": {"name": new_name},
+        "id": 1,
+    }
+    result = put_group_socket(message)
+    result = loads(result)
+
+    assert result["group"]["id"] == 1
+    assert result["group"]["name"] == new_name
+    assert database.session.query(Group).get(1).name == new_name
+
+
+def test_put_group_missing_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    new_name = "Brand New Hospital A"
+    message = {"token": token.decode("UTF-8"), "group": {"name": new_name}, "id": 1}
+    result = put_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Missing request key!"
+
+
+def test_put_group_missing_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    new_name = "Brand New Hospital A"
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "group": {"name": new_name},
+        "id": 1,
+    }
+    result = put_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Missing request key!"
+
+
+def test_put_group_invalid_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    new_name = "Brand New Hospital A"
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {
+        "private-key": "invalid85b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+        "id": 1,
+        "group": {"name": new_name},
+        "id": 1,
+    }
+
+    result = put_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Invalid credentials!"
+
+
+def test_put_group_invalid_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, "thewrongsecret")
+    new_name = "Brand New Hospital A"
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+        "id": 1,
+        "group": {"name": new_name},
+    }
+    result = put_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Invalid credentials!"
+
+
+def test_put_group_unauthorized(client, database, cleanup):
+    new_role = create_role(*user_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    new_name = "Brand New Hospital A"
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+        "id": 1,
+        "group": {"name": new_name},
+    }
+    result = put_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "User is not authorized for this operation!"
+
+
+def test_put_group_missing_group(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    new_name = "Brand New Hospital A"
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+        "id": 1,
+        "group": {"name": new_name},
+    }
+    result = put_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Group ID not found!"
+
+
+# DELETE GROUP
+
+
+def test_delete_group_success(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    assert database.session.query(Group).get(1) is not None
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "id": 1,
+        "token": token.decode("UTF-8"),
+    }
+    result = delete_group_socket(message)
+    result = loads(result)
+
+    assert database.session.query(Group).get(1) is None
+
+
+def test_delete_group_missing_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {"token": token.decode("UTF-8"), "id": 1}
+    result = delete_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Missing request key!"
+
+
+def test_delete_group_missing_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "id": 1,
+    }
+    result = delete_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Missing request key!"
+
+
+def test_delete_group_invalid_key(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {
+        "private-key": "invalid85b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+        "id": 1,
+    }
+    result = delete_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Invalid credentials!"
+
+
+def test_put_delete_invalid_token(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, "thewrongsecret")
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+        "id": 1,
+    }
+    result = delete_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Invalid credentials!"
+
+
+def test_delete_group_unauthorized(client, database, cleanup):
+    new_role = create_role(*user_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+    new_group = Group(name="Hospital X")
+    database.session.add(new_group)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+        "id": 1,
+    }
+    result = delete_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "User is not authorized for this operation!"
+
+
+def test_delete_group_missing_group(client, database, cleanup):
+    new_role = create_role(*admin_role)
+    database.session.add(new_role)
+    new_user = create_user(*user1)
+    database.session.add(new_user)
+
+    database.session.commit()
+
+    token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
+    message = {
+        "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
+        "token": token.decode("UTF-8"),
+        "id": 1,
+    }
+    result = delete_group_socket(message)
+    result = loads(result)
+
+    assert result["error"] == "Group ID not found!"


### PR DESCRIPTION
## Description
Adds Group related endpoints for the Node application in both http and websocket versions.

Fixes #635 

## Affected Dependencies
- None

## How has this been tested?
* Unit tests for each endpoint (ws / http) including tests for:
   + bad request
   + missing resource
   + unauthorized operation
   + border cases
   + effect of requests on database

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
