### PR TITLE
Handle request_id globally

### DIFF
--- a/apps/node/src/app/main/events/__init__.py
+++ b/apps/node/src/app/main/events/__init__.py
@@ -66,12 +66,19 @@ def route_requests(message, socket):
     if isinstance(message, bytearray):
         return forward_binary_message(message)
 
+    request_id = None
     try:
         message = json.loads(message)
+        request_id = message.get(MSG_FIELD.REQUEST_ID)
         response = routes[message[REQUEST_MSG.TYPE_FIELD]](message)
-        return response
+        if request_id:
+            response[MSG_FIELD.REQUEST_ID] = request_id
     except Exception as e:
-        return json.dumps({"error": str(e)})
+        response = {"error": str(e)}
+        if request_id:
+            response[MSG_FIELD.REQUEST_ID] = request_id
+
+    return json.dumps(response)
 
 
 @ws.route("/")

--- a/apps/node/src/app/main/events/__init__.py
+++ b/apps/node/src/app/main/events/__init__.py
@@ -71,12 +71,11 @@ def route_requests(message, socket):
         message = json.loads(message)
         request_id = message.get(MSG_FIELD.REQUEST_ID)
         response = routes[message[REQUEST_MSG.TYPE_FIELD]](message)
-        if request_id:
-            response[MSG_FIELD.REQUEST_ID] = request_id
     except Exception as e:
         response = {"error": str(e)}
-        if request_id:
-            response[MSG_FIELD.REQUEST_ID] = request_id
+
+    if request_id:
+        response[MSG_FIELD.REQUEST_ID] = request_id
 
     return json.dumps(response)
 

--- a/apps/node/src/app/main/events/data_centric/control_events.py
+++ b/apps/node/src/app/main/events/data_centric/control_events.py
@@ -37,13 +37,9 @@ def authentication(message: dict) -> dict:
     # If it was authenticated
     if user:
         login_user(user)
-        return {
-            RESPONSE_MSG.SUCCESS: "True", RESPONSE_MSG.NODE_ID: user.worker.id
-        }
+        return {RESPONSE_MSG.SUCCESS: "True", RESPONSE_MSG.NODE_ID: user.worker.id}
     else:
-        return {
-            RESPONSE_MSG.ERROR: "Invalid username/password!"
-        }
+        return {RESPONSE_MSG.ERROR: "Invalid username/password!"}
 
 
 def connect_grid_nodes(message: dict) -> dict:

--- a/apps/node/src/app/main/events/data_centric/control_events.py
+++ b/apps/node/src/app/main/events/data_centric/control_events.py
@@ -13,53 +13,53 @@ from ...core.codes import MSG_FIELD
 from ...data_centric.auth import authenticated_only, get_session
 
 
-def get_node_infos(message: dict) -> str:
+def get_node_infos(message: dict) -> dict:
     """Returns node id.
 
     Returns:
-        response (str) : Response message containing node id.
+        response (dict) : Response message containing node id.
     """
-    return json.dumps(
-        {
-            RESPONSE_MSG.NODE_ID: local_worker.id,
-            MSG_FIELD.SYFT_VERSION: sy.version.__version__,
-        }
-    )
+    return {
+        RESPONSE_MSG.NODE_ID: local_worker.id,
+        MSG_FIELD.SYFT_VERSION: sy.version.__version__,
+    }
 
 
-def authentication(message: dict) -> str:
+def authentication(message: dict) -> dict:
     """Receive user credentials and performs user authentication.
 
     Args:
         message (dict) : Dict data structure containing user credentials.
     Returns:
-        response (str) : Authentication response message.
+        response (dict) : Authentication response message.
     """
     user = get_session().authenticate(message)
     # If it was authenticated
     if user:
         login_user(user)
-        return json.dumps(
-            {RESPONSE_MSG.SUCCESS: "True", RESPONSE_MSG.NODE_ID: user.worker.id}
-        )
+        return {
+            RESPONSE_MSG.SUCCESS: "True", RESPONSE_MSG.NODE_ID: user.worker.id
+        }
     else:
-        return json.dumps({RESPONSE_MSG.ERROR: "Invalid username/password!"})
+        return {
+            RESPONSE_MSG.ERROR: "Invalid username/password!"
+        }
 
 
-def connect_grid_nodes(message: dict) -> str:
+def connect_grid_nodes(message: dict) -> dict:
     """Connect remote grid nodes between each other.
 
     Args:
         message (dict) :  Dict data structure containing node_id, node address and user credentials(optional).
     Returns:
-        response (str) : response message.
+        response (dict) : response message.
     """
     if message["id"] not in local_worker._known_workers:
         worker = DataCentricFLClient(hook, address=message["address"], id=message["id"])
-    return json.dumps({"status": "Succesfully connected."})
+    return {"status": "Succesfully connected."}
 
 
 @authenticated_only
-def socket_ping(message: dict) -> str:
+def socket_ping(message: dict) -> dict:
     """Ping request to check node's health state."""
-    return json.dumps({"alive": "True"})
+    return {"alive": "True"}

--- a/apps/node/src/app/main/events/data_centric/model_events.py
+++ b/apps/node/src/app/main/events/data_centric/model_events.py
@@ -124,9 +124,6 @@ def run_inference(message: dict) -> dict:
 
         # We can now remove data from the objects
         del data
-        return {
-            RESPONSE_MSG.SUCCESS: True,
-            RESPONSE_MSG.INFERENCE_RESULT: predictions
-        }
+        return {RESPONSE_MSG.SUCCESS: True, RESPONSE_MSG.INFERENCE_RESULT: predictions}
     else:
         return response

--- a/apps/node/src/app/main/events/data_centric/model_events.py
+++ b/apps/node/src/app/main/events/data_centric/model_events.py
@@ -18,13 +18,13 @@ from ...data_centric.persistence.object_storage import recover_objects
 
 
 @authenticated_only
-def host_model(message: dict) -> str:
+def host_model(message: dict) -> dict:
     """Save/Store a model into database.
 
     Args:
         message (dict) : Dict containing a serialized model and model's metadata.
     Response:
-        response (str) : Node's response.
+        response (dict) : Node's response.
     """
     encoding = message["encoding"]
     model_id = message[MSG_FIELD.MODEL_ID]
@@ -45,42 +45,42 @@ def host_model(message: dict) -> str:
         allow_remote_inference,
         mpc,
     )
-    return json.dumps(response)
+    return response
 
 
 @authenticated_only
-def delete_model(message: dict) -> str:
+def delete_model(message: dict) -> dict:
     """Delete a model previously stored at database.
 
     Args:
         message (dict) : Model's id.
     Returns:
-        response (str) : Node's response.
+        response (dict) : Node's response.
     """
     model_id = message[MSG_FIELD.MODEL_ID]
     result = model_controller.delete(current_user.worker, model_id)
-    return json.dumps(result)
+    return result
 
 
 @authenticated_only
-def get_models(message: dict) -> str:
+def get_models(message: dict) -> dict:
     """Get a list of stored models.
 
     Returns:
-        response (str) : List of models stored at this node.
+        response (dict) : List of models stored at this node.
     """
     model_list = model_controller.models(current_user.worker)
-    return json.dumps(model_list)
+    return model_list
 
 
 @authenticated_only
-def run_inference(message: dict) -> str:
+def run_inference(message: dict) -> dict:
     """Run dataset inference with a specifc model stored in this node.
 
     Args:
         message (dict) : Serialized dataset, model id and dataset's metadata.
     Returns:
-        response (str) : Model's inference.
+        response (dict) : Model's inference.
     """
     ## If worker is empty, load previous database tensors.
     if not current_user.worker._objects:
@@ -92,13 +92,11 @@ def run_inference(message: dict) -> str:
 
         # If model exists but not allow remote inferences
         if not response[MSG_FIELD.PROPERTIES][MSG_FIELD.ALLOW_REMOTE_INFERENCE]:
-            return json.dumps(
-                {
-                    MSG_FIELD.SUCCESS: False,
-                    "not_allowed": True,
-                    RESPONSE_MSG.ERROR: "You're not allowed to run inferences on this model.",
-                }
-            )
+            return {
+                MSG_FIELD.SUCCESS: False,
+                "not_allowed": True,
+                RESPONSE_MSG.ERROR: "You're not allowed to run inferences on this model.",
+            }
 
         model = response[MSG_FIELD.PROPERTIES][MSG_FIELD.MODEL]
 
@@ -126,8 +124,9 @@ def run_inference(message: dict) -> str:
 
         # We can now remove data from the objects
         del data
-        return json.dumps(
-            {RESPONSE_MSG.SUCCESS: True, RESPONSE_MSG.INFERENCE_RESULT: predictions}
-        )
+        return {
+            RESPONSE_MSG.SUCCESS: True,
+            RESPONSE_MSG.INFERENCE_RESULT: predictions
+        }
     else:
-        return json.dumps(response)
+        return response

--- a/apps/node/src/app/main/events/model_centric/control_events.py
+++ b/apps/node/src/app/main/events/model_centric/control_events.py
@@ -5,6 +5,6 @@ import json
 from ...core.codes import MSG_FIELD
 
 
-def socket_ping(message: dict) -> str:
+def socket_ping(message: dict) -> dict:
     """Ping request to check node's health state."""
-    return json.dumps({MSG_FIELD.ALIVE: "True"})
+    return {MSG_FIELD.ALIVE: "True"}

--- a/apps/node/src/app/main/events/model_centric/fl_events.py
+++ b/apps/node/src/app/main/events/model_centric/fl_events.py
@@ -24,7 +24,7 @@ from ..socket_handler import SocketHandler
 handler = SocketHandler()
 
 
-def host_federated_training(message: dict, socket=None) -> str:
+def host_federated_training(message: dict, socket=None) -> dict:
     """This will allow for training cycles to begin on end-user devices.
 
     Args:
@@ -71,10 +71,10 @@ def host_federated_training(message: dict, socket=None) -> str:
         MSG_FIELD.DATA: response,
     }
 
-    return json.dumps(response)
+    return response
 
 
-def assign_worker_id(message: dict, socket=None) -> str:
+def assign_worker_id(message: dict, socket=None) -> dict:
     """New workers should receive a unique worker ID after authenticate on
     PyGrid platform.
 
@@ -128,7 +128,7 @@ def requires_speed_test(model_name, model_version):
     )
 
 
-def authenticate(message: dict, socket=None) -> str:
+def authenticate(message: dict, socket=None) -> dict:
     """Check the submitted token and assign the worker a new id.
 
     Args:
@@ -138,7 +138,6 @@ def authenticate(message: dict, socket=None) -> str:
         response : String response to the client
     """
     data = message.get("data")
-    request_id = message.get("request_id")
     response = {}
 
     try:
@@ -162,13 +161,12 @@ def authenticate(message: dict, socket=None) -> str:
 
     response = {
         MSG_FIELD.TYPE: MODEL_CENTRIC_FL_EVENTS.AUTHENTICATE,
-        MSG_FIELD.REQUEST_ID: request_id,
         MSG_FIELD.DATA: response,
     }
-    return json.dumps(response)
+    return response
 
 
-def cycle_request(message: dict, socket=None) -> str:
+def cycle_request(message: dict, socket=None) -> dict:
     """This event is where the worker is attempting to join an active federated
     learning cycle.
 
@@ -179,7 +177,6 @@ def cycle_request(message: dict, socket=None) -> str:
         response : String response to the client
     """
     data = message[MSG_FIELD.DATA]
-    request_id = message[MSG_FIELD.REQUEST_ID]
     response = {}
 
     try:
@@ -232,13 +229,12 @@ def cycle_request(message: dict, socket=None) -> str:
 
     response = {
         MSG_FIELD.TYPE: MODEL_CENTRIC_FL_EVENTS.CYCLE_REQUEST,
-        MSG_FIELD.REQUEST_ID: request_id,
         MSG_FIELD.DATA: response,
     }
-    return json.dumps(response)
+    return response
 
 
-def report(message: dict, socket=None) -> str:
+def report(message: dict, socket=None) -> dict:
     """This method will allow a worker that has been accepted into a cycle and
     finished training a model on their device to upload the resulting model
     diff.
@@ -250,7 +246,6 @@ def report(message: dict, socket=None) -> str:
         response : String response to the client
     """
     data = message[MSG_FIELD.DATA]
-    request_id = message[MSG_FIELD.REQUEST_ID]
     response = {}
 
     try:
@@ -271,7 +266,6 @@ def report(message: dict, socket=None) -> str:
 
     response = {
         MSG_FIELD.TYPE: MODEL_CENTRIC_FL_EVENTS.REPORT,
-        MSG_FIELD.REQUEST_ID: request_id,
         MSG_FIELD.DATA: response,
     }
-    return json.dumps(response)
+    return response

--- a/apps/node/src/app/main/events/role_related.py
+++ b/apps/node/src/app/main/events/role_related.py
@@ -41,14 +41,14 @@ def get_token(*args, **kwargs):
 
 
 def format_result(response_body, status_code, mimetype):
-    return dumps(response_body)
+    return response_body
 
 
 token_required = token_required_factory(get_token, format_result)
 
 
 @token_required
-def create_role_socket(current_user, message: dict) -> str:
+def create_role_socket(current_user, message: dict) -> dict:
     def route_logic(current_user, message: dict) -> dict:
         private_key = message.get("private-key")
         role = message.get("role")
@@ -70,11 +70,11 @@ def create_role_socket(current_user, message: dict) -> str:
 
     status_code, response_body = error_handler(route_logic, current_user, message)
 
-    return dumps(response_body)
+    return response_body
 
 
 @token_required
-def get_role_socket(current_user, message: dict) -> str:
+def get_role_socket(current_user, message: dict) -> dict:
     def route_logic(current_user, message: dict) -> dict:
         private_key = message.get("private-key")
         role_id = message.get("id")
@@ -91,11 +91,11 @@ def get_role_socket(current_user, message: dict) -> str:
 
     status_code, response_body = error_handler(route_logic, current_user, message)
 
-    return dumps(response_body)
+    return response_body
 
 
 @token_required
-def get_all_roles_socket(current_user, message: dict) -> str:
+def get_all_roles_socket(current_user, message: dict) -> dict:
     def route_logic(current_user, message: dict) -> dict:
         private_key = message.get("private-key")
 
@@ -111,11 +111,11 @@ def get_all_roles_socket(current_user, message: dict) -> str:
 
     status_code, response_body = error_handler(route_logic, current_user, message)
 
-    return dumps(response_body)
+    return response_body
 
 
 @token_required
-def put_role_socket(current_user, message: dict) -> str:
+def put_role_socket(current_user, message: dict) -> dict:
     def route_logic(current_user, message: dict) -> dict:
         private_key = message.get("private-key")
         role_id = message.get("id")
@@ -133,11 +133,11 @@ def put_role_socket(current_user, message: dict) -> str:
 
     status_code, response_body = error_handler(route_logic, current_user, message)
 
-    return dumps(response_body)
+    return response_body
 
 
 @token_required
-def delete_role_socket(current_user, message: dict) -> str:
+def delete_role_socket(current_user, message: dict) -> dict:
     def route_logic(current_user, message: dict) -> dict:
         private_key = message.get("private-key")
         role_id = message.get("id")
@@ -154,4 +154,4 @@ def delete_role_socket(current_user, message: dict) -> str:
 
     status_code, response_body = error_handler(route_logic, current_user, message)
 
-    return dumps(response_body)
+    return response_body

--- a/apps/node/src/app/main/events/user_related.py
+++ b/apps/node/src/app/main/events/user_related.py
@@ -48,13 +48,13 @@ def get_token(*args, **kwargs):
 
 
 def format_result(response_body, status_code, mimetype):
-    return dumps(response_body)
+    return response_body
 
 
 token_required = token_required_factory(get_token, format_result)
 
 
-def signup_user_socket(message: dict) -> str:
+def signup_user_socket(message: dict) -> dict:
     def route_logic(message: dict) -> dict:
         private_key = user = user_role = None
         private_key = message.get("private-key")
@@ -73,10 +73,10 @@ def signup_user_socket(message: dict) -> str:
 
     status_code, response_body = error_handler(route_logic, message)
 
-    return dumps(response_body)
+    return response_body
 
 
-def login_user_socket(message: dict) -> str:
+def login_user_socket(message: dict) -> dict:
     def route_logic(message: dict) -> dict:
 
         email = message.get("email")
@@ -92,11 +92,11 @@ def login_user_socket(message: dict) -> str:
 
     status_code, response_body = error_handler(route_logic, message)
 
-    return dumps(response_body)
+    return response_body
 
 
 @token_required
-def get_all_users_socket(current_user: User, message: dict) -> str:
+def get_all_users_socket(current_user: User, message: dict) -> dict:
     def route_logic(current_user: User, message: dict) -> dict:
         private_key = message.get("private-key")
         if private_key is None:
@@ -112,11 +112,11 @@ def get_all_users_socket(current_user: User, message: dict) -> str:
 
     status_code, response_body = error_handler(route_logic, current_user, message)
 
-    return dumps(response_body)
+    return response_body
 
 
 @token_required
-def get_specific_user_socket(current_user: User, message: dict) -> str:
+def get_specific_user_socket(current_user: User, message: dict) -> dict:
     def route_logic(current_user: User, message: dict) -> dict:
         user_id = message.get("id")
         private_key = message.get("private-key")
@@ -133,11 +133,11 @@ def get_specific_user_socket(current_user: User, message: dict) -> str:
 
     status_code, response_body = error_handler(route_logic, current_user, message)
 
-    return dumps(response_body)
+    return response_body
 
 
 @token_required
-def change_user_email_socket(current_user: User, message: dict) -> str:
+def change_user_email_socket(current_user: User, message: dict) -> dict:
     def route_logic(current_user: User, message: dict) -> dict:
         user_id = message.get("id")
         email = message.get("email")
@@ -155,11 +155,11 @@ def change_user_email_socket(current_user: User, message: dict) -> str:
 
     status_code, response_body = error_handler(route_logic, current_user, message)
 
-    return dumps(response_body)
+    return response_body
 
 
 @token_required
-def change_user_role_socket(current_user: User, message: dict) -> str:
+def change_user_role_socket(current_user: User, message: dict) -> dict:
     def route_logic(current_user: User, message: dict) -> dict:
         user_id = message.get("id")
         role = message.get("role")
@@ -177,11 +177,11 @@ def change_user_role_socket(current_user: User, message: dict) -> str:
 
     status_code, response_body = error_handler(route_logic, current_user, message)
 
-    return dumps(response_body)
+    return response_body
 
 
 @token_required
-def change_user_password_socket(current_user: User, message: dict) -> str:
+def change_user_password_socket(current_user: User, message: dict) -> dict:
     def route_logic(current_user: User, message: dict) -> dict:
         user_id = message.get("id")
         password = message.get("password")
@@ -200,11 +200,11 @@ def change_user_password_socket(current_user: User, message: dict) -> str:
 
     status_code, response_body = error_handler(route_logic, current_user, message)
 
-    return dumps(response_body)
+    return response_body
 
 
 @token_required
-def change_user_groups_socket(current_user: User, message: dict) -> str:
+def change_user_groups_socket(current_user: User, message: dict) -> dict:
     def route_logic(current_user: User, message: dict) -> dict:
         user_id = message.get("id")
         groups = message.get("groups")
@@ -222,11 +222,11 @@ def change_user_groups_socket(current_user: User, message: dict) -> str:
 
     status_code, response_body = error_handler(route_logic, current_user, message)
 
-    return dumps(response_body)
+    return response_body
 
 
 @token_required
-def delete_user_socket(current_user: User, message: dict) -> str:
+def delete_user_socket(current_user: User, message: dict) -> dict:
     def route_logic(current_user: User, message: dict) -> dict:
         user_id = message.get("id")
         private_key = message.get("private-key")
@@ -243,11 +243,11 @@ def delete_user_socket(current_user: User, message: dict) -> str:
 
     status_code, response_body = error_handler(route_logic, current_user, message)
 
-    return dumps(response_body)
+    return response_body
 
 
 @token_required
-def search_users_socket(current_user: User, message: dict) -> str:
+def search_users_socket(current_user: User, message: dict) -> dict:
     def route_logic(current_user: User, message: dict) -> dict:
         filters = message.copy()
         filters.pop("private-key", None)
@@ -273,4 +273,4 @@ def search_users_socket(current_user: User, message: dict) -> str:
 
     status_code, response_body = error_handler(route_logic, current_user, message)
 
-    return dumps(response_body)
+    return response_body

--- a/apps/node/tests/websocket_api/test_roles_ws.py
+++ b/apps/node/tests/websocket_api/test_roles_ws.py
@@ -1,5 +1,3 @@
-from json import loads
-
 import jwt
 import pytest
 from flask import current_app as app
@@ -72,8 +70,6 @@ def test_post_role_missing_token(client, database, cleanup):
         "private-key": "3c777d6e1cece1e78aa9c26ae7fa2ecf33a6d3fb1db7c1313e7b79ef3ee884eb",
     }
     result = create_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -92,8 +88,6 @@ def test_post_role_missing_key(client, database, cleanup):
     payload = {"role": role, "token": token.decode("UTF-8")}
 
     result = create_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -110,8 +104,6 @@ def test_post_role_invalid_key(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = create_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -128,8 +120,6 @@ def test_post_role_invalid_token(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = create_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -147,8 +137,6 @@ def test_post_role_user_with_missing_role(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = create_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Role ID not found!"
 
 
@@ -160,8 +148,6 @@ def test_post_role_missing_user(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = create_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -181,8 +167,6 @@ def test_post_role_unauthorized_user(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = create_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "User is not authorized for this operation!"
 
 
@@ -204,8 +188,6 @@ def test_post_role_success(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = create_role_socket(payload)
-    result = loads(result)
-
     expected_role = role.copy()
     expected_role["id"] = 3  # Two roles already inserted
 
@@ -230,8 +212,6 @@ def test_get_all_roles_missing_token(client, database, cleanup):
         "private-key": "3c777d6e1cece1e78aa9c26ae7fa2ecf33a6d3fb1db7c1313e7b79ef3ee884eb"
     }
     result = get_all_roles_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -249,8 +229,6 @@ def test_get_all_roles_missing_key(client, database, cleanup):
     token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
     payload = {"role": role, "token": token.decode("UTF-8")}
     result = get_all_roles_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -271,8 +249,6 @@ def test_get_all_roles_invalid_key(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = get_all_roles_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -293,8 +269,6 @@ def test_get_all_roles_invalid_token(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = get_all_roles_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -311,8 +285,6 @@ def test_get_all_roles_user_with_missing_role(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = get_all_roles_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Role ID not found!"
 
 
@@ -331,8 +303,6 @@ def test_get_all_roles_unauthorized_user(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = get_all_roles_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "User is not authorized for this operation!"
 
 
@@ -354,8 +324,6 @@ def test_get_all_roles_success(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = get_all_roles_socket(payload)
-    result = loads(result)
-
     expected_roles = [model_to_json(role1), model_to_json(role2)]
 
     assert result["roles"] == expected_roles
@@ -376,8 +344,6 @@ def test_get_role_missing_key(client, database, cleanup):
     token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
     payload = {"id": 1, "token": token.decode("UTF-8")}
     result = get_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -395,8 +361,6 @@ def test_get_role_missing_token(client, database, cleanup):
         "private-key": "3c777d6e1cece1e78aa9c26ae7fa2ecf33a6d3fb1db7c1313e7b79ef3ee884eb",
     }
     result = get_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -408,8 +372,6 @@ def test_get_role_invalid_key(client, database, cleanup):
     token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
     payload = {"id": 1, "private-key": "IdoNotExist", "token": token.decode("UTF-8")}
     result = get_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -425,8 +387,6 @@ def test_get_role_invalid_token(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = get_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -438,8 +398,6 @@ def test_get_role_missing_user(client):
         "token": token.decode("UTF-8"),
     }
     result = get_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -455,8 +413,6 @@ def test_get_role_missing_role(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = get_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Role ID not found!"
 
 
@@ -474,8 +430,6 @@ def test_get_role_unauthorized_user(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = get_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "User is not authorized for this operation!"
 
 
@@ -495,8 +449,6 @@ def test_get_role_success(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = get_role_socket(payload)
-    result = loads(result)
-
     expected_role = model_to_json(role1)
 
     assert result["role"] == expected_role
@@ -514,8 +466,6 @@ def test_put_role_missing_key(client, database, cleanup):
     token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
     payload = {"role": role, "id": 1, "token": token.decode("UTF-8")}
     result = put_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -529,8 +479,6 @@ def test_put_role_missing_token(client, database, cleanup):
         "private-key": "3c777d6e1cece1e78aa9c26ae7fa2ecf33a6d3fb1db7c1313e7b79ef3ee884eb"
     }
     result = put_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -551,8 +499,6 @@ def test_put_role_invalid_key(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = put_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -573,8 +519,6 @@ def test_put_role_invalid_token(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = put_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -593,8 +537,6 @@ def test_put_role_user_with_missing_role(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = put_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Role ID not found!"
 
 
@@ -615,8 +557,6 @@ def test_put_role_unauthorized_user(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = put_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "User is not authorized for this operation!"
 
 
@@ -640,8 +580,6 @@ def test_put_over_missing_role(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = put_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Role ID not found!"
 
 
@@ -665,8 +603,6 @@ def test_put_role_success(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = put_role_socket(payload)
-    result = loads(result)
-
     expected_role = role
     expected_role["id"] = 1
 
@@ -688,8 +624,6 @@ def test_delete_role_missing_key(client, database, cleanup):
     token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
     payload = {"id": 2, "token": token.decode("UTF-8")}
     result = delete_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -707,8 +641,6 @@ def test_delete_role_missing_token(client, database, cleanup):
         "private-key": "3c777d6e1cece1e78aa9c26ae7fa2ecf33a6d3fb1db7c1313e7b79ef3ee884eb",
     }
     result = delete_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -728,8 +660,6 @@ def test_delete_role_invalid_key(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = delete_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -749,8 +679,6 @@ def test_delete_role_invalid_token(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = delete_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -768,8 +696,6 @@ def test_delete_role_missing_role(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = delete_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Role ID not found!"
 
 
@@ -787,8 +713,6 @@ def test_delete_role_unauthorized_user(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = delete_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "User is not authorized for this operation!"
 
 
@@ -811,8 +735,6 @@ def test_delete_role_user_with_missing_role(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = delete_role_socket(payload)
-    result = loads(result)
-
     assert result["error"] == "Role ID not found!"
 
 
@@ -835,6 +757,4 @@ def test_delete_role_success(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = delete_role_socket(payload)
-    result = loads(result)
-
     assert database.session.query(Role).get(1) is None

--- a/apps/node/tests/websocket_api/test_users_ws.py
+++ b/apps/node/tests/websocket_api/test_users_ws.py
@@ -1,5 +1,3 @@
-from json import dumps, loads
-
 import jwt
 import pytest
 from bcrypt import checkpw
@@ -79,8 +77,6 @@ def test_post_first_user_success(database, cleanup):
 
     message = {"email": "someemail@email.com", "password": "123secretpassword"}
     result = signup_user_socket(message)
-    result = loads(result)
-
     assert result["success"] == True
     assert result["user"]["id"] == 2
     assert len(result["user"]["private_key"]) == 64
@@ -99,8 +95,6 @@ def test_post_first_user_missing_role(client, database, cleanup):
 
     message = {"email": "someemail@email.com", "password": "123secretpassword"}
     result = signup_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Role ID not found!"
 
 
@@ -121,8 +115,6 @@ def test_post_user_with_role(client, database, cleanup):
         "role": 1,
     }
     result = signup_user_socket(message)
-    result = loads(result)
-
     assert result["success"] == True
     assert result["user"]["id"] == 2
     assert len(result["user"]["private_key"]) == 64
@@ -147,8 +139,6 @@ def test_post_user_invalid_key(client, database, cleanup):
         "role": 1,
     }
     result = signup_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -169,8 +159,6 @@ def test_post_user_with_missing_role(client, database, cleanup):
         "role": 3,
     }
     result = signup_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Role ID not found!"
 
 
@@ -190,8 +178,6 @@ def test_login_user_valid_credentials(client, database, cleanup):
         "password": "&UP!SN!;J4Mx;+A]",
     }
     result = login_user_socket(message)
-    result = loads(result)
-
     assert result["success"] == True
     token = result["token"]
     content = jwt.decode(token, app.config["SECRET_KEY"], algorithms="HS256")
@@ -214,8 +200,6 @@ def test_login_user_invalid_key(client, database, cleanup):
         "password": "&UP!SN!;J4Mx;+A]",
     }
     result = login_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -231,8 +215,6 @@ def test_login_user_missing_key(client, database, cleanup):
 
     message = {"email": "tech@gibberish.com", "password": "&UP!SN!;J4Mx;+A]"}
     result = login_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -252,8 +234,6 @@ def test_login_user_invalid_email(client, database, cleanup):
         "password": "&UP!SN!;J4Mx;+A]",
     }
     result = login_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -273,8 +253,6 @@ def test_login_user_invalid_password(client, database, cleanup):
         "password": "@123456notmypassword",
     }
     result = login_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -299,8 +277,6 @@ def test_get_users_success(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = get_all_users_socket(message)
-    result = loads(result)
-
     assert len(result["users"]) == 2
     assert result["users"][0]["id"] == 1
     assert result["users"][1]["id"] == 2
@@ -324,8 +300,6 @@ def test_get_users_unauthorized(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = get_all_users_socket(message)
-    result = loads(result)
-
     assert result["error"] == "User is not authorized for this operation!"
 
 
@@ -344,8 +318,6 @@ def test_get_users_missing_key(client, database, cleanup):
     token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
     message = {"token": token.decode("UTF-8")}
     result = get_all_users_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -365,8 +337,6 @@ def test_get_users_missing_token(client, database, cleanup):
         "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced"
     }
     result = get_all_users_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -388,8 +358,6 @@ def test_get_users_invalid_key(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = get_all_users_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -411,8 +379,6 @@ def test_get_users_invalid_token(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = get_all_users_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -438,8 +404,6 @@ def test_get_one_user_success(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = get_specific_user_socket(message)
-    result = loads(result)
-
     assert result["user"]["id"] == 2
     assert result["user"]["email"] == "anemail@anemail.com"
 
@@ -459,8 +423,6 @@ def test_get_one_user_missing_key(client, database, cleanup):
     token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
     message = {"id": 1, "token": token.decode("UTF-8")}
     result = get_specific_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -481,8 +443,6 @@ def test_get_one_user_missing_token(client, database, cleanup):
         "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
     }
     result = get_specific_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -505,8 +465,6 @@ def test_get_one_user_invalid_key(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = get_specific_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -529,8 +487,6 @@ def test_get_one_user_invalid_token(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = get_specific_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -553,8 +509,6 @@ def test_get_one_user_unauthorized(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = get_specific_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "User is not authorized for this operation!"
 
 
@@ -577,8 +531,6 @@ def test_get_one_missing_user(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = get_specific_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "User ID not found!"
 
 
@@ -607,8 +559,6 @@ def test_put_other_user_email_success(client, database, cleanup):
         "email": "brandnew@brandnewemail.com",
     }
     result = change_user_email_socket(message)
-    result = loads(result)
-
     assert result["user"]["id"] == 2
     assert result["user"]["email"] == "brandnew@brandnewemail.com"
     assert database.session.query(User).get(2).email == "brandnew@brandnewemail.com"
@@ -635,8 +585,6 @@ def test_put_other_user_email_missing_key(client, database, cleanup):
         "email": "brandnew@brandnewemail.com",
     }
     result = change_user_email_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -659,8 +607,6 @@ def test_put_other_user_email_missing_token(client, database, cleanup):
     }
     message = {"id": 2, "email": "brandnew@brandnewemail.com"}
     result = change_user_email_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -686,8 +632,6 @@ def test_put_user_email_invalid_key(client, database, cleanup):
         "email": "brandnew@brandnewemail.com",
     }
     result = change_user_email_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -713,8 +657,6 @@ def test_put_user_email_invalid_token(client, database, cleanup):
         "email": "brandnew@brandnewemail.com",
     }
     result = change_user_email_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -738,8 +680,6 @@ def test_put_other_user_email_unauthorized(client, database, cleanup):
         "email": "brandnew@brandnewemail.com",
     }
     result = change_user_email_socket(message)
-    result = loads(result)
-
     assert result["error"] == "User is not authorized for this operation!"
 
 
@@ -765,8 +705,6 @@ def test_put_own_user_email_success(client, database, cleanup):
         "email": "brandnew@brandnewemail.com",
     }
     result = change_user_email_socket(message)
-    result = loads(result)
-
     assert result["user"]["id"] == 2
     assert result["user"]["email"] == "brandnew@brandnewemail.com"
     assert database.session.query(User).get(2).email == "brandnew@brandnewemail.com"
@@ -792,8 +730,6 @@ def test_put_user_email_missing_role(client, database, cleanup):
         "email": "brandnew@brandnewemail.com",
     }
     result = change_user_email_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Role ID not found!"
 
 
@@ -815,8 +751,6 @@ def test_put_other_user_email_missing_user(client, database, cleanup):
         "email": "brandnew@brandnewemail.com",
     }
     result = change_user_email_socket(message)
-    result = loads(result)
-
     assert result["error"] == "User ID not found!"
 
 
@@ -845,8 +779,6 @@ def test_put_other_user_role_success(client, database, cleanup):
         "id": 2,
     }
     result = change_user_role_socket(message)
-    result = loads(result)
-
     assert result["user"]["id"] == 2
     assert result["user"]["role"]["id"] == 1
     assert database.session.query(User).get(2).role == 1
@@ -867,8 +799,6 @@ def test_put_other_user_role_missing_key(client, database, cleanup):
     token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
     message = {"token": token.decode("UTF-8"), "role": 1, "id": 2}
     result = change_user_role_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -889,8 +819,6 @@ def test_put_other_user_role_missing_token(client, database, cleanup):
     }
     message = {"role": 1, "id": 2}
     result = change_user_role_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -914,8 +842,6 @@ def test_put_user_role_invalid_key(client, database, cleanup):
         "id": 2,
     }
     result = change_user_role_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -939,8 +865,6 @@ def test_put_user_role_invalid_token(client, database, cleanup):
         "id": 2,
     }
     result = change_user_role_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -964,8 +888,6 @@ def test_put_other_user_role_unauthorized(client, database, cleanup):
         "id": 1,
     }
     result = change_user_role_socket(message)
-    result = loads(result)
-
     assert result["error"] == "User is not authorized for this operation!"
 
 
@@ -1001,8 +923,6 @@ def test_put_own_user_role_sucess(client, database, cleanup):
         "id": 2,
     }
     result = change_user_role_socket(message)
-    result = loads(result)
-
     assert result["user"]["id"] == 2
     assert result["user"]["role"]["id"] == 3
     assert database.session.query(User).get(2).role == 3
@@ -1038,8 +958,6 @@ def test_put_first_user_unauthorized(client, database, cleanup):
         "id": 1,
     }
     result = change_user_role_socket(message)
-    result = loads(result)
-
     assert result["error"] == "User is not authorized for this operation!"
 
 
@@ -1073,8 +991,6 @@ def test_put_other_user_role_owner_unauthorized(client, database, cleanup):
         "id": 3,
     }
     result = change_user_role_socket(message)
-    result = loads(result)
-
     assert result["error"] == "User is not authorized for this operation!"
 
 
@@ -1110,8 +1026,6 @@ def test_put_other_user_role_owner_success(client, database, cleanup):
         "id": 3,
     }
     result = change_user_role_socket(message)
-    result = loads(result)
-
     assert result["user"]["id"] == 3
     assert result["user"]["role"]["id"] == 1
     assert database.session.query(User).get(3).role == 1
@@ -1135,8 +1049,6 @@ def test_put_user_role_missing_role(client, database, cleanup):
         "id": 2,
     }
     result = change_user_role_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Role ID not found!"
 
 
@@ -1158,8 +1070,6 @@ def test_put_other_user_role_missing_user(client, database, cleanup):
         "id": 2,
     }
     result = change_user_role_socket(message)
-    result = loads(result)
-
     assert result["error"] == "User ID not found!"
 
 
@@ -1200,8 +1110,6 @@ def test_put_other_user_password_success(client, database, cleanup):
     }
 
     result = change_user_password_socket(message)
-    result = loads(result)
-
     assert result["user"]["id"] == 2
     assert checkpw(
         new_password.encode("UTF-8"),
@@ -1226,8 +1134,6 @@ def test_put_user_password_missing_key(client, database, cleanup):
     message = {"token": token.decode("UTF-8"), "id": 2, "password": new_password}
 
     result = change_user_password_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -1250,8 +1156,6 @@ def test_put_user_password_missing_token(client, database, cleanup):
         "password": new_password,
     }
     result = change_user_password_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -1276,8 +1180,6 @@ def test_put_user_password_invalid_key(client, database, cleanup):
         "password": new_password,
     }
     result = change_user_password_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -1302,8 +1204,6 @@ def test_put_user_password_invalid_token(client, database, cleanup):
         "password": new_password,
     }
     result = change_user_password_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -1328,8 +1228,6 @@ def test_put_other_user_password_unauthorized(client, database, cleanup):
         "password": new_password,
     }
     result = change_user_password_socket(message)
-    result = loads(result)
-
     assert result["error"] == "User is not authorized for this operation!"
 
 
@@ -1370,8 +1268,6 @@ def test_put_own_user_password_success(client, database, cleanup):
         "password": new_password,
     }
     result = change_user_password_socket(message)
-    result = loads(result)
-
     assert result["user"]["id"] == 3
     assert checkpw(
         new_password.encode("UTF-8"),
@@ -1398,8 +1294,6 @@ def test_put_other_user_email_missing_user(client, database, cleanup):
         "password": new_password,
     }
     result = change_user_password_socket(message)
-    result = loads(result)
-
     assert result["error"] == "User ID not found!"
 
 
@@ -1444,7 +1338,6 @@ def test_put_other_user_groups_success(client, database, cleanup):
         "groups": [2, 3],
     }
     result = change_user_groups_socket(message)
-    result = loads(result)
     user_groups = database.session.query(UserGroup).filter_by(user=2).all()
 
     assert result["user"]["id"] == 2
@@ -1481,7 +1374,6 @@ def test_put_user_groups_missing_key(client, database, cleanup):
     token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
     message = {"token": token.decode("UTF-8"), "id": 2, "groups": [2, 3]}
     result = change_user_groups_socket(message)
-    result = loads(result)
     user_groups = database.session.query(UserGroup).filter_by(user=2).all()
 
     assert result["error"] == "Missing request key!"
@@ -1513,8 +1405,6 @@ def test_put_user_groups_missing_token(client, database, cleanup):
         "id": 2,
     }
     result = change_user_groups_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -1546,8 +1436,6 @@ def test_put_user_groups_invalid_key(client, database, cleanup):
         "groups": [2, 3],
     }
     result = change_user_groups_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -1579,8 +1467,6 @@ def test_put_user_groups_invalid_token(client, database, cleanup):
         "groups": [2, 3],
     }
     result = change_user_groups_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -1612,8 +1498,6 @@ def test_put_other_user_groups_unauthorized(client, database, cleanup):
         "groups": [2, 3],
     }
     result = change_user_groups_socket(message)
-    result = loads(result)
-
     assert result["error"] == "User is not authorized for this operation!"
 
 
@@ -1661,7 +1545,6 @@ def test_put_own_user_groups_success(client, database, cleanup):
         "groups": [1],
     }
     result = change_user_groups_socket(message)
-    result = loads(result)
     user_groups = database.session.query(UserGroup).filter_by(user=3).all()
 
     assert result["user"]["id"] == 3
@@ -1700,8 +1583,6 @@ def test_put_other_user_groups_missing_user(client, database, cleanup):
         "groups": [1],
     }
     result = change_user_groups_socket(message)
-    result = loads(result)
-
     assert result["error"] == "User ID not found!"
 
 
@@ -1745,7 +1626,6 @@ def test_put_user_groups_missing_group(client, database, cleanup):
         "groups": [5],
     }
     result = change_user_groups_socket(message)
-    result = loads(result)
     user_groups = database.session.query(UserGroup).filter_by(user=3).all()
 
     assert result["error"] == "Group ID not found!"
@@ -1781,8 +1661,6 @@ def test_delete_other_user_success(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = delete_user_socket(message)
-    result = loads(result)
-
     assert database.session.query(User).get(2) is None
 
 
@@ -1801,8 +1679,6 @@ def test_delete_user_missing_key(client, database, cleanup):
     token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
     message = {"id": 1, "token": token.decode("UTF-8")}
     result = delete_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -1823,8 +1699,6 @@ def test_delete_user_missing_token(client, database, cleanup):
         "private-key": "fd062d885b24bda173f6aa534a3418bcafadccecfefe2f8c6f5a8db563549ced",
     }
     result = delete_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -1847,8 +1721,6 @@ def test_delete_user_invalid_key(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = delete_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -1871,8 +1743,6 @@ def test_delete_user_invalid_token(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = delete_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -1895,8 +1765,6 @@ def test_delete_other_user_unauthorized(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = delete_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "User is not authorized for this operation!"
 
 
@@ -1931,7 +1799,6 @@ def test_delete_own_user_success(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = delete_user_socket(message)
-    result = loads(result)
     user_groups = database.session.query(UserGroup).filter_by(user=3).all()
 
     assert database.session.query(User).get(3) is None
@@ -1954,8 +1821,6 @@ def test_delete_other_user_missing_user(client, database, cleanup):
         "token": token.decode("UTF-8"),
     }
     result = delete_user_socket(message)
-    result = loads(result)
-
     assert result["error"] == "User ID not found!"
 
 
@@ -1987,8 +1852,6 @@ def test_search_users_success(client, database, cleanup):
         "email": "anemail@anemail.com",
     }
     result = search_users_socket(message)
-    result = loads(result)
-
     assert result["success"] == True
     assert len(result["users"]) == 1
     assert result["users"][0]["id"] == 2
@@ -2043,8 +1906,6 @@ def test_search_users_nomatch(client, database, cleanup):
         "group": 3,
     }
     result = search_users_socket(message)
-    result = loads(result)
-
     assert result["success"] == True
     assert len(result["users"]) == 0
 
@@ -2105,8 +1966,6 @@ def test_search_users_onematch(client, database, cleanup):
         "email": "tech@gibberish.com",
     }
     result = search_users_socket(message)
-    result = loads(result)
-
     assert result["success"] == True
     assert len(result["users"]) == 1
     assert result["users"][0]["id"] == 2
@@ -2127,8 +1986,6 @@ def test_search_users_missing_key(client, database, cleanup):
     token = jwt.encode({"id": 1}, app.config["SECRET_KEY"])
     message = {"token": token.decode("UTF-8"), "email": "anemail@anemail.com"}
     result = search_users_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -2149,8 +2006,6 @@ def test_search_users_missing_token(client, database, cleanup):
         "email": "anemail@anemail.com",
     }
     result = search_users_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Missing request key!"
 
 
@@ -2173,8 +2028,6 @@ def test_search_users_invalid_key(client, database, cleanup):
         "email": "anemail@anemail.com",
     }
     result = search_users_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -2197,8 +2050,6 @@ def test_search_users_invalid_token(client, database, cleanup):
         "email": "anemail@anemail.com",
     }
     result = search_users_socket(message)
-    result = loads(result)
-
     assert result["error"] == "Invalid credentials!"
 
 
@@ -2221,6 +2072,4 @@ def test_search_users_unauthorized(client, database, cleanup):
         "email": "anemail@anemail.com",
     }
     result = search_users_socket(message)
-    result = loads(result)
-
     assert result["error"] == "User is not authorized for this operation!"


### PR DESCRIPTION
## Description
Improving #715 to return request id in all WS responses including errors.

## Affected Dependencies
n/a

## How has this been tested?
- Unit tests
- Manually tested MC flow

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
