### PR TITLE
add boto3 in setup.py for pygrid CLI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="OpenMined PyGrid CLI",
     version="0.0.1",
     packages=["apps.cli",],
-    install_requires=["click", "PyInquirer", "terrascript"],
+    install_requires=["click", "PyInquirer", "terrascript", "boto3"],
     entry_points="""
         [console_scripts]
         pygrid=apps.cli.cli:cli


### PR DESCRIPTION
## Description
add a missing requirement in setup.py for Pygrid CLI

## Affected Dependencies
- boto3

## How has this been tested?


## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
