### PR TITLE
Remove syft decorators

### DIFF
--- a/apps/domain/src/main/core/services/association_request.py
+++ b/apps/domain/src/main/core/services/association_request.py
@@ -12,7 +12,6 @@ from syft.core.node.abstract.node import AbstractNode
 from syft.core.node.common.service.auth import service_auth
 from syft.core.node.common.service.node_service import ImmediateNodeServiceWithReply
 from syft.core.node.common.service.node_service import ImmediateNodeServiceWithoutReply
-from syft.decorators.syft_decorator_impl import syft_decorator
 from syft.core.common.message import ImmediateSyftMessageWithReply
 
 from syft.grid.messages.association_messages import (
@@ -31,7 +30,6 @@ from syft.grid.messages.association_messages import (
 )
 
 
-@syft_decorator(typechecking=True)
 def send_association_request_msg(
     msg: SendAssociationRequestMessage,
 ) -> SendAssociationRequestResponse:
@@ -42,7 +40,6 @@ def send_association_request_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def recv_association_request_msg(
     msg: ReceiveAssociationRequestMessage,
 ) -> ReceiveAssociationRequestResponse:
@@ -53,7 +50,6 @@ def recv_association_request_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def respond_association_request_msg(
     msg: RespondAssociationRequestMessage,
 ) -> RespondAssociationRequestResponse:
@@ -64,7 +60,6 @@ def respond_association_request_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def get_association_request_msg(
     msg: GetAssociationRequestMessage,
 ) -> GetAssociationRequestResponse:
@@ -75,7 +70,6 @@ def get_association_request_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def get_all_association_request_msg(
     msg: GetAssociationRequestsMessage,
 ) -> GetAssociationRequestsResponse:
@@ -86,7 +80,6 @@ def get_all_association_request_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def del_association_request_msg(
     msg: DeleteAssociationRequestMessage,
 ) -> DeleteAssociationRequestResponse:

--- a/apps/domain/src/main/core/services/group_service.py
+++ b/apps/domain/src/main/core/services/group_service.py
@@ -12,7 +12,6 @@ from syft.core.node.abstract.node import AbstractNode
 from syft.core.node.common.service.auth import service_auth
 from syft.core.node.common.service.node_service import ImmediateNodeServiceWithReply
 from syft.core.node.common.service.node_service import ImmediateNodeServiceWithoutReply
-from syft.decorators.syft_decorator_impl import syft_decorator
 from syft.core.common.message import ImmediateSyftMessageWithReply
 
 from syft.grid.messages.group_messages import (
@@ -31,7 +30,6 @@ from syft.grid.messages.group_messages import (
 from ..database.utils import model_to_json
 
 
-@syft_decorator(typechecking=True)
 def create_group_msg(
     msg: CreateGroupMessage,
     node: AbstractNode,
@@ -68,7 +66,6 @@ def create_group_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def update_group_msg(
     msg: UpdateGroupMessage,
     node: AbstractNode,
@@ -107,7 +104,6 @@ def update_group_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def get_group_msg(
     msg: GetGroupMessage,
     node: AbstractNode,
@@ -144,7 +140,6 @@ def get_group_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def get_all_groups_msg(
     msg: GetGroupsMessage,
     node: AbstractNode,
@@ -177,7 +172,6 @@ def get_all_groups_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def del_group_msg(
     msg: DeleteGroupMessage,
     node: AbstractNode,

--- a/apps/domain/src/main/core/services/infra_service.py
+++ b/apps/domain/src/main/core/services/infra_service.py
@@ -13,7 +13,6 @@ from syft.core.node.abstract.node import AbstractNode
 from syft.core.node.common.service.auth import service_auth
 from syft.core.node.common.service.node_service import ImmediateNodeServiceWithReply
 from syft.core.node.common.service.node_service import ImmediateNodeServiceWithoutReply
-from syft.decorators.syft_decorator_impl import syft_decorator
 from syft.core.common.message import ImmediateSyftMessageWithReply
 
 from syft.grid.messages.infra_messages import (
@@ -33,7 +32,6 @@ from syft.grid.messages.infra_messages import (
 )
 
 
-@syft_decorator(typechecking=True)
 def create_worker_msg(
     msg: CreateWorkerMessage,
     node: AbstractNode,
@@ -69,7 +67,6 @@ def create_worker_msg(
         )
 
 
-@syft_decorator(typechecking=True)
 def check_worker_deployment_msg(
     msg: CheckWorkerDeploymentMessage,
     node: AbstractNode,
@@ -94,7 +91,6 @@ def check_worker_deployment_msg(
         )
 
 
-@syft_decorator(typechecking=True)
 def get_worker_msg(
     msg: GetWorkerMessage,
     node: AbstractNode,
@@ -121,7 +117,6 @@ def get_worker_msg(
         )
 
 
-@syft_decorator(typechecking=True)
 def get_workers_msg(
     msg: GetWorkersMessage,
     node: AbstractNode,
@@ -153,7 +148,6 @@ def get_workers_msg(
         )
 
 
-@syft_decorator(typechecking=True)
 def del_worker_msg(
     msg: DeleteWorkerMessage,
     node: AbstractNode,
@@ -165,7 +159,6 @@ def del_worker_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def update_worker_msg(
     msg: UpdateWorkerMessage,
     node: AbstractNode,

--- a/apps/domain/src/main/core/services/role_service.py
+++ b/apps/domain/src/main/core/services/role_service.py
@@ -12,7 +12,6 @@ from syft.core.node.abstract.node import AbstractNode
 from syft.core.node.common.service.auth import service_auth
 from syft.core.node.common.service.node_service import ImmediateNodeServiceWithReply
 from syft.core.node.common.service.node_service import ImmediateNodeServiceWithoutReply
-from syft.decorators.syft_decorator_impl import syft_decorator
 from syft.core.common.message import ImmediateSyftMessageWithReply
 
 from syft.grid.messages.role_messages import (
@@ -29,7 +28,6 @@ from syft.grid.messages.role_messages import (
 )
 
 
-@syft_decorator(typechecking=True)
 def create_role_msg(
     msg: CreateRoleMessage,
 ) -> CreateRoleResponse:
@@ -40,7 +38,6 @@ def create_role_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def update_role_msg(
     msg: UpdateRoleMessage,
 ) -> UpdateRoleResponse:
@@ -51,7 +48,6 @@ def update_role_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def get_role_msg(
     msg: GetRoleMessage,
 ) -> GetRoleResponse:
@@ -71,7 +67,6 @@ def get_role_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def get_all_roles_msg(
     msg: GetRolesMessage,
 ) -> GetRolesResponse:
@@ -105,7 +100,6 @@ def get_all_roles_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def del_role_msg(
     msg: DeleteRoleMessage,
 ) -> DeleteRoleResponse:

--- a/apps/domain/src/main/core/services/setup_service.py
+++ b/apps/domain/src/main/core/services/setup_service.py
@@ -12,7 +12,6 @@ from syft.core.node.abstract.node import AbstractNode
 from syft.core.node.common.service.auth import service_auth
 from syft.core.node.common.service.node_service import ImmediateNodeServiceWithReply
 from syft.core.node.common.service.node_service import ImmediateNodeServiceWithoutReply
-from syft.decorators.syft_decorator_impl import syft_decorator
 from syft.core.common.message import ImmediateSyftMessageWithReply
 
 from syft.grid.messages.setup_messages import (
@@ -23,7 +22,6 @@ from syft.grid.messages.setup_messages import (
 )
 
 
-@syft_decorator(typechecking=True)
 def create_initial_setup(
     msg: CreateInitialSetUpMessage,
     node: AbstractNode,
@@ -53,7 +51,6 @@ def create_initial_setup(
         )
 
 
-@syft_decorator(typechecking=True)
 def get_setup(
     msg: GetSetUpMessage,
     node: AbstractNode,

--- a/apps/domain/src/main/core/services/tensor_service.py
+++ b/apps/domain/src/main/core/services/tensor_service.py
@@ -15,7 +15,6 @@ from syft.core.node.abstract.node import AbstractNode
 from syft.core.node.common.service.auth import service_auth
 from syft.core.node.common.service.node_service import ImmediateNodeServiceWithReply
 from syft.core.node.common.service.node_service import ImmediateNodeServiceWithoutReply
-from syft.decorators.syft_decorator_impl import syft_decorator
 from syft.core.common.message import ImmediateSyftMessageWithReply
 from syft.core.common.uid import UID
 from syft.core.node.common.action.save_object_action import SaveObjectAction
@@ -34,7 +33,6 @@ from syft.grid.messages.tensor_messages import (
 )
 
 
-@syft_decorator(typechecking=True)
 def create_tensor_msg(
     msg: CreateTensorMessage,
     node: AbstractNode,
@@ -79,7 +77,6 @@ def create_tensor_msg(
         )
 
 
-@syft_decorator(typechecking=True)
 def update_tensor_msg(
     msg: UpdateTensorMessage,
     node: AbstractNode,
@@ -121,7 +118,6 @@ def update_tensor_msg(
         )
 
 
-@syft_decorator(typechecking=True)
 def get_tensor_msg(
     msg: GetTensorMessage,
     node: AbstractNode,
@@ -151,7 +147,6 @@ def get_tensor_msg(
         )
 
 
-@syft_decorator(typechecking=True)
 def get_tensors_msg(
     msg: GetTensorsMessage,
     node: AbstractNode,
@@ -180,7 +175,6 @@ def get_tensors_msg(
         )
 
 
-@syft_decorator(typechecking=True)
 def del_tensor_msg(
     msg: DeleteTensorMessage,
     node: AbstractNode,

--- a/apps/domain/src/main/core/services/user_service.py
+++ b/apps/domain/src/main/core/services/user_service.py
@@ -15,7 +15,6 @@ from syft.core.node.abstract.node import AbstractNode
 from syft.core.node.common.service.auth import service_auth
 from syft.core.node.common.service.node_service import ImmediateNodeServiceWithReply
 from syft.core.node.common.service.node_service import ImmediateNodeServiceWithoutReply
-from syft.decorators.syft_decorator_impl import syft_decorator
 from syft.core.common.message import ImmediateSyftMessageWithReply
 
 from syft.grid.messages.user_messages import (
@@ -44,7 +43,6 @@ from ..database.utils import model_to_json
 from ..database import expand_user_object
 
 
-@syft_decorator(typechecking=True)
 def create_user_msg(
     msg: CreateUserMessage,
     node: AbstractNode,
@@ -126,7 +124,6 @@ def create_user_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def update_user_msg(
     msg: UpdateUserMessage,
     node: AbstractNode,
@@ -207,7 +204,6 @@ def update_user_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def get_user_msg(
     msg: GetUserMessage,
     node: AbstractNode,
@@ -233,7 +229,6 @@ def get_user_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def get_all_users_msg(
     msg: GetUsersMessage,
     node: AbstractNode,
@@ -257,7 +252,6 @@ def get_all_users_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def del_user_msg(
     msg: DeleteUserMessage,
     node: AbstractNode,
@@ -287,7 +281,6 @@ def del_user_msg(
     )
 
 
-@syft_decorator(typechecking=True)
 def search_users_msg(
     msg: SearchUsersMessage,
     node: AbstractNode,


### PR DESCRIPTION
## Description
Removes syft decorators from `apps/domains/*`.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
