### PR TITLE
Fix MCFL API HTTP responses

### DIFF
--- a/apps/domain/src/main/routes/model_centric/routes.py
+++ b/apps/domain/src/main/routes/model_centric/routes.py
@@ -44,17 +44,14 @@ def worker_cycle_request():
 
     try:
         body = json.loads(request.data)
-        response_body = cycle_request({MSG_FIELD.DATA: body}, None)
+        result = cycle_request({MSG_FIELD.DATA: body}, None)
+        response_body = result.get(MSG_FIELD.DATA)
     except (PyGridError, json.decoder.JSONDecodeError) as e:
         status_code = 400  # Bad Request
         response_body[RESPONSE_MSG.ERROR] = str(e)
     except Exception as e:
         status_code = 500  # Internal Server Error
         response_body[RESPONSE_MSG.ERROR] = str(e)
-
-    if isinstance(response_body, str):
-        # Consider just data field as a response
-        response_body = json.loads(response_body)[MSG_FIELD.DATA]
 
     response_body = json.dumps(response_body)
     return Response(response_body, status=status_code, mimetype="application/json")
@@ -108,17 +105,14 @@ def report_diff():
 
     try:
         body = json.loads(request.data)
-        response_body = report({MSG_FIELD.DATA: body}, None)
+        result = report({MSG_FIELD.DATA: body}, None)
+        response_body = result.get(MSG_FIELD.DATA)
     except (PyGridError, json.decoder.JSONDecodeError) as e:
         status_code = 400  # Bad Request
         response_body[RESPONSE_MSG.ERROR] = str(e)
     except Exception as e:
         status_code = 500  # Internal Server Error
         response_body[RESPONSE_MSG.ERROR] = str(e)
-
-    if isinstance(response_body, str):
-        # Consider just data field as a response
-        response_body = json.loads(response_body)[MSG_FIELD.DATA]
 
     response_body = json.dumps(response_body)
     return Response(response_body, status=status_code, mimetype="application/json")


### PR DESCRIPTION
## Description
`cycle-request` and `report` HTTP endpoints return `{type: x, data: y}` in the response (same as WS), but it should return just contents of the `data` field.
Workers using HTTP API will say thank you for this fix :) 

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
