### PR TITLE
Make success code customizable for APIs 

### DIFF
--- a/apps/domain/src/main/routes/association_requests/routes.py
+++ b/apps/domain/src/main/routes/association_requests/routes.py
@@ -35,7 +35,7 @@ def send_association_request(current_user):
     content["sender_address"] = sender_address
 
     status_code, response_msg = error_handler(
-        route_logic, SendAssociationRequestMessage, current_user, content
+        route_logic, 200, SendAssociationRequestMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -55,7 +55,7 @@ def recv_association_request():
         content = {}
 
     status_code, response_msg = error_handler(
-        route_logic, ReceiveAssociationRequestMessage, None, content
+        route_logic, 200, ReceiveAssociationRequestMessage, None, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -84,7 +84,7 @@ def reply_association_request(current_user):
     content["sender_address"] = sender_address
 
     status_code, response_msg = error_handler(
-        route_logic, RespondAssociationRequestMessage, current_user, content
+        route_logic, 200, RespondAssociationRequestMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -105,7 +105,7 @@ def get_all_association_requests(current_user):
         content = {}
 
     status_code, response_msg = error_handler(
-        route_logic, GetAssociationRequestsMessage, current_user, content
+        route_logic, 200, GetAssociationRequestsMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -129,7 +129,7 @@ def get_specific_association_requests(current_user, association_request_id):
     content["association_request_id"] = association_request_id
 
     status_code, response_msg = error_handler(
-        route_logic, GetAssociationRequestMessage, current_user, content
+        route_logic, 200, GetAssociationRequestMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -153,7 +153,7 @@ def delete_association_requests(current_user, association_request_id):
     content["association_request_id"] = association_request_id
 
     status_code, response_msg = error_handler(
-        route_logic, DeleteAssociationRequestMessage, current_user, content
+        route_logic, 204, DeleteAssociationRequestMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content

--- a/apps/domain/src/main/routes/auth.py
+++ b/apps/domain/src/main/routes/auth.py
@@ -75,8 +75,8 @@ token_required = token_required_factory(get_token, format_result)
 optional_token = token_required_factory(get_token, format_result, optional=True)
 
 
-def error_handler(f, *args, **kwargs):
-    status_code = 200  # Success
+def error_handler(f, success_code, *args, **kwargs):
+    status_code = success_code  # Success
     response_body = {}
 
     try:

--- a/apps/domain/src/main/routes/data_centric/datasets/routes.py
+++ b/apps/domain/src/main/routes/data_centric/datasets/routes.py
@@ -85,7 +85,7 @@ def get_dataset_info(current_user, dataset_id):
     content["current_user"] = current_user
     content["dataset_id"] = dataset_id
     status_code, response_msg = error_handler(
-        route_logic, GetDatasetMessage, current_user, content
+        route_logic, 200, GetDatasetMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -103,7 +103,7 @@ def get_all_datasets_info(current_user):
     content = {}
     content["current_user"] = current_user
     status_code, response_msg = error_handler(
-        route_logic, GetDatasetsMessage, current_user, content
+        route_logic, 200, GetDatasetsMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -123,7 +123,7 @@ def update_dataset(current_user, dataset_id):
     content["current_user"] = current_user
     content["dataset_id"] = dataset_id
     status_code, response_msg = error_handler(
-        route_logic, UpdateDatasetMessage, current_user, content
+        route_logic, 204, UpdateDatasetMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -144,12 +144,10 @@ def delete_dataset(current_user, dataset_id):
     content["dataset_id"] = dataset_id
 
     status_code, response_msg = error_handler(
-        route_logic, DeleteDatasetMessage, current_user, content
+        route_logic, 204, DeleteDatasetMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
-    if status_code == 200:
-        status_code = 204
 
     return Response(
         dumps(response),

--- a/apps/domain/src/main/routes/data_centric/requests/routes.py
+++ b/apps/domain/src/main/routes/data_centric/requests/routes.py
@@ -31,7 +31,7 @@ def create_request(current_user):
         content = {}
 
     status_code, response_msg = error_handler(
-        route_logic, CreateRequestMessage, current_user, content
+        route_logic, 200, CreateRequestMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -50,7 +50,7 @@ def get_specific_request(current_user, request_id):
     content["request_id"] = request_id
 
     status_code, response_msg = error_handler(
-        route_logic, GetRequestMessage, current_user, content
+        route_logic, 200, GetRequestMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -68,7 +68,7 @@ def get_all_requests(current_user):
     content = {}
 
     status_code, response_msg = error_handler(
-        route_logic, GetRequestsMessage, current_user, content
+        route_logic, 200, GetRequestsMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -91,7 +91,7 @@ def update_request(current_user, request_id):
     content["request_id"] = request_id
 
     status_code, response_msg = error_handler(
-        route_logic, UpdateRequestMessage, current_user, content
+        route_logic, 200, UpdateRequestMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -110,7 +110,7 @@ def delete_request(current_user, request_id):
     content["request_id"] = request_id
 
     status_code, response_msg = error_handler(
-        route_logic, DeleteRequestMessage, current_user, content
+        route_logic, 204, DeleteRequestMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content

--- a/apps/domain/src/main/routes/data_centric/tensors/routes.py
+++ b/apps/domain/src/main/routes/data_centric/tensors/routes.py
@@ -26,7 +26,7 @@ def create_tensor(current_user):
         content = {}
 
     status_code, response_msg = error_handler(
-        route_logic, CreateTensorMessage, current_user, content
+        route_logic, 201, CreateTensorMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -49,7 +49,7 @@ def get_tensor(current_user, tensor_id):
     content["tensor_id"] = tensor_id
 
     status_code, response_msg = error_handler(
-        route_logic, GetTensorMessage, current_user, content
+        route_logic, 200, GetTensorMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -69,7 +69,7 @@ def get_all_tensors():
         content = {}
 
     status_code, response_msg = error_handler(
-        route_logic, GetTensorsMessage, None, content
+        route_logic, 200, GetTensorsMessage, None, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -92,7 +92,7 @@ def update_tensor(current_user, tensor_id):
     content["tensor_id"] = tensor_id
 
     status_code, response_msg = error_handler(
-        route_logic, UpdateTensorMessage, current_user, content
+        route_logic, 204, UpdateTensorMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -115,7 +115,7 @@ def delete_tensor(current_user, tensor_id):
     content["tensor_id"] = tensor_id
 
     status_code, response_msg = error_handler(
-        route_logic, DeleteTensorMessage, current_user, content
+        route_logic, 204, DeleteTensorMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content

--- a/apps/domain/src/main/routes/data_centric/workers/routes.py
+++ b/apps/domain/src/main/routes/data_centric/workers/routes.py
@@ -28,7 +28,7 @@ def get_worker_instance_types(current_user):
         content = {}
 
     status_code, response_msg = error_handler(
-        route_logic, GetWorkerInstanceTypesMessage, current_user, content
+        route_logic, 200, GetWorkerInstanceTypesMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -47,7 +47,7 @@ def create_worker(current_user):
         content = {}
 
     status_code, response_msg = error_handler(
-        route_logic, CreateWorkerMessage, current_user, content
+        route_logic, 200, CreateWorkerMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -77,7 +77,7 @@ def get_all_workers(current_user):
         }
 
     status_code, response_msg = error_handler(
-        route_logic, GetWorkersMessage, current_user, content
+        route_logic, 200, GetWorkersMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -96,7 +96,7 @@ def get_worker(current_user, worker_id):
     content["worker_id"] = worker_id
 
     status_code, response_msg = error_handler(
-        route_logic, GetWorkerMessage, current_user, content
+        route_logic, 200, GetWorkerMessage, current_user, content
     )
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
     return Response(
@@ -114,7 +114,7 @@ def delete_worker(current_user, worker_id):
     content["worker_id"] = worker_id
 
     status_code, response_msg = error_handler(
-        route_logic, DeleteWorkerMessage, current_user, content
+        route_logic, 204, DeleteWorkerMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content

--- a/apps/domain/src/main/routes/general/routes.py
+++ b/apps/domain/src/main/routes/general/routes.py
@@ -17,7 +17,6 @@ from syft.core.common.serde.serialize import _serialize
 # grid relative
 from ...core.exceptions import AuthorizationError
 from ...core.exceptions import UserNotFoundError
-from ..auth import error_handler
 from ..auth import token_required
 from .blueprint import root_blueprint as root_route
 

--- a/apps/domain/src/main/routes/groups/routes.py
+++ b/apps/domain/src/main/routes/groups/routes.py
@@ -27,7 +27,7 @@ def create_group_route(current_user):
     content["current_user"] = current_user
 
     status_code, response_msg = error_handler(
-        route_logic, CreateGroupMessage, current_user, content
+        route_logic, 200, CreateGroupMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -49,7 +49,7 @@ def get_all_groups_routes(current_user):
     content["current_user"] = current_user
 
     status_code, response_msg = error_handler(
-        route_logic, GetGroupsMessage, current_user, content
+        route_logic, 200, GetGroupsMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -72,7 +72,7 @@ def get_specific_group_route(current_user, group_id):
     content["group_id"] = group_id
 
     status_code, response_msg = error_handler(
-        route_logic, GetGroupMessage, current_user, content
+        route_logic, 200, GetGroupMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -95,7 +95,7 @@ def update_group_route(current_user, group_id):
     content["group_id"] = group_id
 
     status_code, response_msg = error_handler(
-        route_logic, UpdateGroupMessage, current_user, content
+        route_logic, 204, UpdateGroupMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -118,7 +118,7 @@ def delete_group_route(current_user, group_id):
     content["group_id"] = group_id
 
     status_code, response_msg = error_handler(
-        route_logic, DeleteGroupMessage, current_user, content
+        route_logic, 204, DeleteGroupMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content

--- a/apps/domain/src/main/routes/roles/routes.py
+++ b/apps/domain/src/main/routes/roles/routes.py
@@ -26,7 +26,7 @@ def create_role_route(current_user):
         content = {}
 
     status_code, response_msg = error_handler(
-        route_logic, CreateRoleMessage, current_user, content
+        route_logic, 204, CreateRoleMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -48,7 +48,7 @@ def get_role_route(current_user, role_id):
     content["role_id"] = role_id
 
     status_code, response_msg = error_handler(
-        route_logic, GetRoleMessage, current_user, content
+        route_logic, 200, GetRoleMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -69,7 +69,7 @@ def get_all_roles_route(current_user):
         content = {}
 
     status_code, response_msg = error_handler(
-        route_logic, GetRolesMessage, current_user, content
+        route_logic, 200, GetRolesMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -91,7 +91,7 @@ def put_role_route(current_user, role_id):
     content["role_id"] = role_id
 
     status_code, response_msg = error_handler(
-        route_logic, UpdateRoleMessage, current_user, content
+        route_logic, 204, UpdateRoleMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -113,7 +113,7 @@ def delete_role_route(current_user, role_id):
     content["role_id"] = role_id
 
     status_code, response_msg = error_handler(
-        route_logic, DeleteRoleMessage, current_user, content
+        route_logic, 204, DeleteRoleMessage, current_user, content
     )
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
 

--- a/apps/domain/src/main/routes/search/routes.py
+++ b/apps/domain/src/main/routes/search/routes.py
@@ -23,7 +23,7 @@ def broadcast_search(current_user):
         content = {}
 
     status_code, response_msg = error_handler(
-        route_logic, NetworkSearchMessage, current_user, content
+        route_logic, 200, NetworkSearchMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content

--- a/apps/domain/src/main/routes/setup/routes.py
+++ b/apps/domain/src/main/routes/setup/routes.py
@@ -24,7 +24,7 @@ def initial_setup(current_user):
         content = {}
 
     status_code, response_msg = error_handler(
-        route_logic, CreateInitialSetUpMessage, current_user, content
+        route_logic, 200, CreateInitialSetUpMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -45,7 +45,7 @@ def get_setup(current_user):
         content = {}
 
     status_code, response_msg = error_handler(
-        route_logic, GetSetUpMessage, current_user, content
+        route_logic, 200, GetSetUpMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content

--- a/apps/domain/src/main/routes/users/routes.py
+++ b/apps/domain/src/main/routes/users/routes.py
@@ -42,7 +42,7 @@ def create_user(current_user):
         content = {}
     content["current_user"] = current_user
     status_code, response_msg = error_handler(
-        route_logic, CreateUserMessage, current_user, content
+        route_logic, 204, CreateUserMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -74,7 +74,7 @@ def login_route():
         )
         return response_body
 
-    status_code, response_body = error_handler(route_logic)
+    status_code, response_body = error_handler(route_logic, 200)
 
     return Response(
         json.dumps(response_body), status=status_code, mimetype="application/json"
@@ -85,7 +85,7 @@ def login_route():
 @token_required
 def get_all_users_route(current_user):
     status_code, response_msg = error_handler(
-        route_logic, GetUsersMessage, current_user, {}
+        route_logic, 200, GetUsersMessage, current_user, {}
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -105,7 +105,7 @@ def get_specific_user_route(current_user, user_id):
     content["user_id"] = user_id
 
     status_code, response_msg = error_handler(
-        route_logic, GetUserMessage, current_user, content
+        route_logic, 200, GetUserMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -127,7 +127,7 @@ def change_user_email_route(current_user, user_id):
     content["user_id"] = user_id
 
     status_code, response_msg = error_handler(
-        route_logic, UpdateUserMessage, current_user, content
+        route_logic, 204, UpdateUserMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -149,7 +149,7 @@ def change_user_role_route(current_user, user_id):
     content["user_id"] = user_id
 
     status_code, response_msg = error_handler(
-        route_logic, UpdateUserMessage, current_user, content
+        route_logic, 204, UpdateUserMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -171,7 +171,7 @@ def change_user_password_role(current_user, user_id):
     content["user_id"] = user_id
 
     status_code, response_msg = error_handler(
-        route_logic, UpdateUserMessage, current_user, content
+        route_logic, 204, UpdateUserMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -193,7 +193,7 @@ def change_user_groups_route(current_user, user_id):
     content["user_id"] = user_id
 
     status_code, response_msg = error_handler(
-        route_logic, UpdateUserMessage, current_user, content
+        route_logic, 204, UpdateUserMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -212,7 +212,7 @@ def delete_user_role(current_user, user_id):
     content["user_id"] = user_id
 
     status_code, response_msg = error_handler(
-        route_logic, DeleteUserMessage, current_user, content
+        route_logic, 204, DeleteUserMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content
@@ -233,7 +233,7 @@ def search_users_route(current_user):
         content = {}
 
     status_code, response_msg = error_handler(
-        route_logic, SearchUsersMessage, current_user, content
+        route_logic, 200, SearchUsersMessage, current_user, content
     )
 
     response = response_msg if isinstance(response_msg, dict) else response_msg.content

--- a/apps/domain/tests/test_routes/test_requests.py
+++ b/apps/domain/tests/test_routes/test_requests.py
@@ -329,6 +329,4 @@ def test_delete_request(client, database, cleanup):
         content_type="application/json",
     )
 
-    response = result.get_json()
-    assert result.status_code == 200
-    assert response["msg"] == "Request deleted!"
+    assert result.status_code == 204

--- a/apps/domain/tests/test_routes/test_roles_http.py
+++ b/apps/domain/tests/test_routes/test_roles_http.py
@@ -175,8 +175,7 @@ def test_post_role_success(client, database, cleanup):
     expected_role = payload.copy()
     expected_role["id"] = 3  # Two roles already inserted
 
-    assert result.status_code == 200
-    assert result.get_json() == {"msg": "Role created successfully!"}
+    assert result.status_code == 204
 
 
 # GET ALL ROLES
@@ -594,8 +593,7 @@ def test_put_role_success(client, database, cleanup):
         headers=headers,
     )
 
-    assert result.status_code == 200
-    assert result.get_json() == {"msg": "Role updated successfully!"}
+    assert result.status_code == 204
 
 
 # DELETE ROLE
@@ -714,5 +712,4 @@ def test_delete_role_success(client, database, cleanup):
     }
     result = client.delete("/roles/2", headers=headers)
 
-    assert result.status_code == 200
-    assert result.get_json() == {"msg": "Role has been deleted!"}
+    assert result.status_code == 204

--- a/apps/domain/tests/test_routes/test_tensors.py
+++ b/apps/domain/tests/test_routes/test_tensors.py
@@ -136,7 +136,8 @@ def test_create_tensor(client, database, cleanup):
         },
         headers=headers,
     )
-    assert result.status_code == 200
+
+    assert result.status_code == 201
     assert result.get_json()["msg"] == "Tensor created succesfully!"
 
 
@@ -227,8 +228,7 @@ def test_update_tensor(client, database, cleanup):
         },
         headers=headers,
     )
-    assert result.status_code == 200
-    assert result.get_json()["msg"] == "Tensor modified succesfully!"
+    assert result.status_code == 204
 
     # Assert updated tensor metadata
     result = client.get("/data-centric/tensors/" + tensor_id, headers=headers)
@@ -270,5 +270,4 @@ def test_delete_tensor(client, database, cleanup):
 
     result = client.delete("/data-centric/tensors/" + tensor_id, headers=headers)
 
-    assert result.status_code == 200
-    assert result.get_json() == {"msg": "Tensor deleted successfully!"}
+    assert result.status_code == 204

--- a/apps/domain/tests/test_routes/test_users_http.py
+++ b/apps/domain/tests/test_routes/test_users_http.py
@@ -62,7 +62,7 @@ def cleanup(database):
 # POST USER
 
 
-def test_post_role_user_data_no_key(client):
+def test_post_user_bad_data_no_key(client):
     result = client.post("/users", data="{bad", content_type="application/json")
     assert result.status_code == 400
 
@@ -92,8 +92,7 @@ def test_post_std_user_success(client, database, cleanup):
     payload = {"email": "someemail@email.com", "password": "123secretpassword"}
     result = client.post("/users", data=dumps(payload), content_type="application/json")
 
-    assert result.status_code == 200
-    assert result.get_json() == {"message": "User created successfully!"}
+    assert result.status_code == 204
 
 
 def test_post_std_user_missing_role(client, database, cleanup):
@@ -120,6 +119,7 @@ def test_post_std_user_missing_role(client, database, cleanup):
         "/users", data=dumps(payload), headers=headers, content_type="application/json"
     )
 
+    assert result.status_code == 404
     assert result.get_json() == {"error": "Role ID not found!"}
 
 
@@ -146,8 +146,7 @@ def test_post_user_with_role(client, database, cleanup):
         "/users", data=dumps(payload), headers=headers, content_type="application/json"
     )
 
-    assert result.status_code == 200
-    assert result.get_json() == {"message": "User created successfully!"}
+    assert result.status_code == 204
 
 
 def test_login_user_valid_credentials(client, database, cleanup):
@@ -462,8 +461,7 @@ def test_put_other_user_email_success(client, database, cleanup):
         content_type="application/json",
     )
 
-    assert result.status_code == 200
-    assert result.get_json() == {"message": "User updated successfully!"}
+    assert result.status_code == 204
 
 
 def test_put_other_user_email_missing_token(client, database, cleanup):
@@ -577,8 +575,7 @@ def test_put_own_user_email_success(client, database, cleanup):
         content_type="application/json",
     )
 
-    assert result.status_code == 200
-    assert result.get_json() == {"message": "User updated successfully!"}
+    assert result.status_code == 204
 
 
 def test_put_user_email_missing_role(client, database, cleanup):
@@ -605,8 +602,7 @@ def test_put_user_email_missing_role(client, database, cleanup):
         content_type="application/json",
     )
 
-    assert result.status_code == 200
-    assert result.get_json() == {"message": "User updated successfully!"}
+    assert result.status_code == 204
 
 
 def test_put_other_user_email_missing_user(client, database, cleanup):
@@ -664,8 +660,7 @@ def test_put_other_user_role_success(client, database, cleanup):
         content_type="application/json",
     )
 
-    assert result.status_code == 200
-    assert result.get_json() == {"message": "User updated successfully!"}
+    assert result.status_code == 204
 
 
 def test_put_other_user_role_missing_token(client, database, cleanup):
@@ -785,8 +780,7 @@ def test_put_own_user_role_sucess(client, database, cleanup):
         content_type="application/json",
     )
 
-    assert result.status_code == 200
-    assert result.get_json() == {"message": "User updated successfully!"}
+    assert result.status_code == 204
 
 
 def test_put_first_user_unauthorized(client, database, cleanup):
@@ -1005,8 +999,7 @@ def test_put_other_user_password_success(client, database, cleanup):
         content_type="application/json",
     )
 
-    assert result.status_code == 200
-    assert result.get_json() == {"message": "User updated successfully!"}
+    assert result.status_code == 204
     assert checkpw(
         new_password.encode("UTF-8"),
         user.salt.encode("UTF-8") + user.hashed_password.encode("UTF-8"),
@@ -1144,8 +1137,7 @@ def test_put_own_user_password_success(client, database, cleanup):
         content_type="application/json",
     )
 
-    assert result.status_code == 200
-    assert result.get_json() == {"message": "User updated successfully!"}
+    assert result.status_code == 204
     assert checkpw(
         new_password.encode("UTF-8"),
         user.salt.encode("UTF-8") + user.hashed_password.encode("UTF-8"),
@@ -1226,8 +1218,7 @@ def test_put_other_user_groups_success(client, database, cleanup):
     )
     user_groups = database.session.query(UserGroup).filter_by(user=2).all()
 
-    assert result.status_code == 200
-    assert result.get_json() == {"message": "User updated successfully!"}
+    assert result.status_code == 204
 
     assert len(user_groups) == 2
     assert user_groups[0].group == 2
@@ -1394,8 +1385,7 @@ def test_put_user_groups_success(client, database, cleanup):
     )
     user_groups = database.session.query(UserGroup).filter_by(user=3).all()
 
-    assert result.status_code == 200
-    assert result.get_json() == {"message": "User updated successfully!"}
+    assert result.status_code == 204
 
     assert len(user_groups) == 1
     assert user_groups[0].group == 1
@@ -1522,8 +1512,7 @@ def test_delete_other_user_success(client, database, cleanup):
     }
     result = client.delete("/users/2", headers=headers, content_type="application/json")
 
-    assert result.status_code == 200
-    assert result.get_json() == {"message": "User deleted successfully!"}
+    assert result.status_code == 204
     assert database.session.query(User).get(2) is None
 
 


### PR DESCRIPTION
## Description

* Update `routes/auth.py` to make the success code a parameter.

* Update routes with no meaningful return on success, no resources / links to resources, to employ 204 as their success code (e.g. `UPDATE` and `DELETE`):
```bash
-    assert result.status_code == 200                                                                                     
-    assert result.get_json() == {"message": "User updated successfully!"}                                                
+    assert result.status_code == 204    
````

## How has this been tested?
- Updated existing unit tests

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
