### PR TITLE
[WIP] Make PyGrid Node and Network API's a no-delete database

### DIFF
--- a/apps/domain/src/main/core/database/association/association.py
+++ b/apps/domain/src/main/core/database/association/association.py
@@ -1,3 +1,5 @@
+from sqlalchemy.sql import func
+
 # grid relative
 from .. import BaseModel
 from .. import db
@@ -19,6 +21,9 @@ class Association(BaseModel):
     date = db.Column(db.DateTime())
     name = db.Column(db.String(255))
     address = db.Column(db.String(255))
+    created_at = db.Column(db.DateTime(timezone=False), server_default=func.now())
+    updated_at = db.Column(db.DateTime(timezone=False), onupdate=func.now())
+    deleted_at = db.Column(db.DateTime(timezone=False), default=None)
 
     def __str__(self):
         return f"< Association id : {self.id}, Name: {self.name}, Address: {self.address}, Date: {self.date}>"

--- a/apps/domain/src/main/core/database/association/request.py
+++ b/apps/domain/src/main/core/database/association/request.py
@@ -1,3 +1,5 @@
+from sqlalchemy.sql import func
+
 # grid relative
 from .. import BaseModel
 from .. import db
@@ -26,6 +28,9 @@ class AssociationRequest(BaseModel):
     accepted = db.Column(db.Boolean(), default=False)
     pending = db.Column(db.Boolean(), default=True)
     handshake_value = db.Column(db.String(255))
+    created_at = db.Column(db.DateTime(timezone=False), server_default=func.now())
+    updated_at = db.Column(db.DateTime(timezone=False), onupdate=func.now())
+    deleted_at = db.Column(db.DateTime(timezone=False), default=None)
 
     def __str__(self):
         return f"< Association Request id : {self.id}, Name: {self.name}, Address: {self.address} , pending: {self.pending}, accepted: {self.accepted}, Date: {self.date}>"

--- a/apps/domain/src/main/core/database/bin_storage/bin_obj.py
+++ b/apps/domain/src/main/core/database/bin_storage/bin_obj.py
@@ -1,4 +1,5 @@
 # third party
+from sqlalchemy.sql import func
 from syft import deserialize
 from syft import serialize
 from syft.proto.lib.pandas.frame_pb2 import PandasDataFrame as PandasDataFrame_PB
@@ -20,6 +21,9 @@ class BinObject(BaseModel):
     id = db.Column(db.String(3072), primary_key=True)
     binary = db.Column(db.LargeBinary(3072))
     protobuf_name = db.Column(db.String(3072))
+    created_at = db.Column(db.DateTime(timezone=False), server_default=func.now())
+    updated_at = db.Column(db.DateTime(timezone=False), onupdate=func.now())
+    deleted_at = db.Column(db.DateTime(timezone=False), default=None)
 
     @property
     def object(self):

--- a/apps/domain/src/main/core/database/bin_storage/json_obj.py
+++ b/apps/domain/src/main/core/database/bin_storage/json_obj.py
@@ -1,3 +1,5 @@
+from sqlalchemy.sql import func
+
 # grid relative
 from .. import BaseModel
 from .. import db
@@ -9,6 +11,9 @@ class JsonObject(BaseModel):
 
     id = db.Column(db.String(), primary_key=True)
     binary = db.Column(db.JSON())
+    created_at = db.Column(db.DateTime(timezone=False), server_default=func.now())
+    updated_at = db.Column(db.DateTime(timezone=False), onupdate=func.now())
+    deleted_at = db.Column(db.DateTime(timezone=False), default=None)
 
     def __str__(self):
         return f"<JsonObject id: {self.id}>"

--- a/apps/domain/src/main/core/database/dataset/datasetgroup.py
+++ b/apps/domain/src/main/core/database/dataset/datasetgroup.py
@@ -1,3 +1,5 @@
+from sqlalchemy.sql import func
+
 # grid relative
 from .. import BaseModel
 from .. import db
@@ -9,6 +11,9 @@ class DatasetGroup(BaseModel):
     id = db.Column(db.Integer(), primary_key=True, autoincrement=True)
     bin_object = db.Column(db.String(), db.ForeignKey("bin_object.id"))
     dataset = db.Column(db.String(), db.ForeignKey("json_object.id"))
+    created_at = db.Column(db.DateTime(timezone=False), server_default=func.now())
+    updated_at = db.Column(db.DateTime(timezone=False), onupdate=func.now())
+    deleted_at = db.Column(db.DateTime(timezone=False), default=None)
 
     def __str__(self):
         return (

--- a/apps/domain/src/main/core/database/environment/environment.py
+++ b/apps/domain/src/main/core/database/environment/environment.py
@@ -1,6 +1,8 @@
 # stdlib
 from datetime import datetime
 
+from sqlalchemy.sql import func
+
 # grid relative
 from .. import BaseModel
 from .. import db
@@ -18,8 +20,9 @@ class Environment(BaseModel):
     instance_type = db.Column(db.String(255))
     address = db.Column(db.String(255), default="0.0.0.0")
     syft_address = db.Column(db.String(255), default="")  # TODO
-    created_at = db.Column(db.DateTime, default=datetime.now())
-    destroyed_at = db.Column(db.DateTime, default=datetime.now())
+    created_at = db.Column(db.DateTime(timezone=False), server_default=func.now())
+    updated_at = db.Column(db.DateTime(timezone=False), onupdate=func.now())
+    deleted_at = db.Column(db.DateTime(timezone=False), default=None)
 
     def __str__(self):
         return f"<Group id: {self.id}, state: {self.state}, address: {self.address}, syft_address: {self.syft_address}, provider: {self.provider}, region: {self.region}, instance_type: {self.instance_type}, created_at: {self.created_at}, destroyed_at: {self.destroyed_at}>"

--- a/apps/domain/src/main/core/database/environment/user_environment.py
+++ b/apps/domain/src/main/core/database/environment/user_environment.py
@@ -1,3 +1,5 @@
+from sqlalchemy.sql import func
+
 # grid relative
 from .. import BaseModel
 from .. import db
@@ -9,6 +11,9 @@ class UserEnvironment(BaseModel):
     id = db.Column(db.Integer(), primary_key=True, autoincrement=True)
     user = db.Column(db.Integer, db.ForeignKey("user.id"))
     environment = db.Column(db.Integer, db.ForeignKey("environment.id"))
+    created_at = db.Column(db.DateTime(timezone=False), server_default=func.now())
+    updated_at = db.Column(db.DateTime(timezone=False), onupdate=func.now())
+    deleted_at = db.Column(db.DateTime(timezone=False), default=None)
 
     def __str__(self):
         return (

--- a/apps/domain/src/main/core/database/groups/groups.py
+++ b/apps/domain/src/main/core/database/groups/groups.py
@@ -1,3 +1,5 @@
+from sqlalchemy.sql import func
+
 # grid relative
 from .. import BaseModel
 from .. import db
@@ -8,6 +10,9 @@ class Group(BaseModel):
 
     id = db.Column(db.Integer(), primary_key=True, autoincrement=True)
     name = db.Column(db.String(255))
+    created_at = db.Column(db.DateTime(timezone=False), server_default=func.now())
+    updated_at = db.Column(db.DateTime(timezone=False), onupdate=func.now())
+    deleted_at = db.Column(db.DateTime(timezone=False), default=None)
 
     def __str__(self):
         return f"<Group id: {self.id}, name: {self.name}>"

--- a/apps/domain/src/main/core/database/groups/usergroup.py
+++ b/apps/domain/src/main/core/database/groups/usergroup.py
@@ -1,3 +1,5 @@
+from sqlalchemy.sql import func
+
 # grid relative
 from .. import BaseModel
 from .. import db
@@ -9,6 +11,9 @@ class UserGroup(BaseModel):
     id = db.Column(db.Integer(), primary_key=True, autoincrement=True)
     user = db.Column(db.Integer, db.ForeignKey("user.id"))
     group = db.Column(db.Integer, db.ForeignKey("group.id"))
+    created_at = db.Column(db.DateTime(timezone=False), server_default=func.now())
+    updated_at = db.Column(db.DateTime(timezone=False), onupdate=func.now())
+    deleted_at = db.Column(db.DateTime(timezone=False), default=None)
 
     def __str__(self):
         return f"<UserGroup id: {self.id}, user: {self.user}, " f"group: {self.group}>"

--- a/apps/domain/src/main/core/database/requests/request.py
+++ b/apps/domain/src/main/core/database/requests/request.py
@@ -1,3 +1,5 @@
+from sqlalchemy.sql import func
+
 # grid relative
 from .. import BaseModel
 from .. import db
@@ -31,6 +33,9 @@ class Request(BaseModel):
     verify_key = db.Column(db.String(255))
     object_type = db.Column(db.String(255))
     tags = db.Column(db.JSON())
+    created_at = db.Column(db.DateTime(timezone=False), server_default=func.now())
+    updated_at = db.Column(db.DateTime(timezone=False), onupdate=func.now())
+    deleted_at = db.Column(db.DateTime(timezone=False), default=None)
 
     def __str__(self):
         return f"< Request id : {self.id}, user: {self.user_id}, Date: {self.date}, Object: {self.object_id}, reason: {self.reason}, status: {self.status}, type: {self.type} >"

--- a/apps/domain/src/main/core/database/roles/roles.py
+++ b/apps/domain/src/main/core/database/roles/roles.py
@@ -1,3 +1,5 @@
+from sqlalchemy.sql import func
+
 # grid relative
 from .. import BaseModel
 from .. import db
@@ -15,6 +17,9 @@ class Role(BaseModel):
     can_edit_roles = db.Column(db.Boolean(), default=False)
     can_manage_infrastructure = db.Column(db.Boolean(), default=False)
     can_upload_data = db.Column(db.Boolean(), default=False)
+    created_at = db.Column(db.DateTime(timezone=False), server_default=func.now())
+    updated_at = db.Column(db.DateTime(timezone=False), onupdate=func.now())
+    deleted_at = db.Column(db.DateTime(timezone=False), default=None)
 
     def __str__(self):
         return (

--- a/apps/domain/src/main/core/database/setup/setup.py
+++ b/apps/domain/src/main/core/database/setup/setup.py
@@ -1,3 +1,5 @@
+from sqlalchemy.sql import func
+
 # grid relative
 from .. import BaseModel
 from .. import db
@@ -17,6 +19,9 @@ class SetupConfig(BaseModel):
     auto_scale = db.Column(db.Boolean(), default=False)
     tensor_expiration_policy = db.Column(db.Integer(), default=0)
     allow_user_signup = db.Column(db.Boolean(), default=False)
+    created_at = db.Column(db.DateTime(timezone=False), server_default=func.now())
+    updated_at = db.Column(db.DateTime(timezone=False), onupdate=func.now())
+    deleted_at = db.Column(db.DateTime(timezone=False), default=None)
 
     def __str__(self):
         return f"<Domain Name: {self.domain_name}, Private Key: {self.private_key}, AWS Credentials: {self.aws_credentials}, GCP Credentials: {self.gcp_credentials}, Azure Credentials: {self.azure_credentials}, Cache Strategy: {self.cache_strategy}, Replicate Database: {self.replicate_db}, Auto Scale: {self.auto_scale}, Tensor Exp Policy: {self.tensor_expiration_policy}, Allow User Signup: {self.allow_user_signup}>"

--- a/apps/domain/src/main/core/database/users/user.py
+++ b/apps/domain/src/main/core/database/users/user.py
@@ -1,4 +1,5 @@
 # grid relative
+from sqlalchemy.sql import func
 from .. import BaseModel
 from .. import db
 
@@ -13,6 +14,9 @@ class User(BaseModel):
     private_key = db.Column(db.String(2048))
     verify_key = db.Column(db.String(2048))
     role = db.Column(db.Integer, db.ForeignKey("role.id"))
+    created_at = db.Column(db.DateTime(timezone=False), server_default=func.now())
+    updated_at = db.Column(db.DateTime(timezone=False), onupdate=func.now())
+    deleted_at = db.Column(db.DateTime(timezone=False), default=None)
 
     def __str__(self):
         return f"<User id: {self.id}, email: {self.email}, " f"role: {self.role}>"

--- a/apps/domain/src/main/core/database/utils.py
+++ b/apps/domain/src/main/core/database/utils.py
@@ -10,7 +10,12 @@ def model_to_json(model):
     json = {}
     for col in model.__mapper__.attrs.keys():
         if col != "hashed_password" and col != "salt":
-            if col == "date" or col == "created_at" or col == "destroyed_at":
+            if (
+                col == "date"
+                or col == "created_at"
+                or col == "deleted_at"
+                or col == "updated_at"
+            ):
                 # Cast datetime object to string
                 json[col] = str(getattr(model, col))
             else:

--- a/apps/domain/src/main/core/manager/user_manager.py
+++ b/apps/domain/src/main/core/manager/user_manager.py
@@ -121,11 +121,8 @@ class UserManager(DatabaseManager):
         return self.role(user_id=user_id).can_create_groups
 
     def role(self, user_id: int):
-        try:
-            user = self.first(id=user_id)
-            return self.roles.first(id=user.role)
-        except UserNotFoundError:
-            return False
+        user = self.first(id=user_id)
+        return self.roles.first(id=user.role)
 
     def __login_validation(self, email: str, password: str) -> bool:
         try:

--- a/apps/domain/src/main/core/services/user_service.py
+++ b/apps/domain/src/main/core/services/user_service.py
@@ -171,7 +171,9 @@ def update_user_msg(
     _allowed = int(_user_id) == int(_current_user_id) or users.can_create_users(
         user_id=_current_user_id
     )
-    _valid_user = users.contain(id=_user_id)
+    _valid_user = (
+        users.contain(id=_user_id) and users.first(id=_user_id).deleted_at is None
+    )
 
     if not _valid_parameters:
         raise MissingRequestKeyError(
@@ -365,6 +367,7 @@ def search_users_msg(
 
     if _allowed:
         try:
+            user_parameters["deleted_at"] = None
             users = node.users.query(**user_parameters)
             if _group:
                 filtered_users = filter(

--- a/apps/domain/tests/test_routes/test_roles_http.py
+++ b/apps/domain/tests/test_routes/test_roles_http.py
@@ -283,30 +283,32 @@ def test_get_all_roles_success(client, database, cleanup):
     result = client.get("/roles", headers=headers)
 
     assert result.status_code == 200
-    assert result.get_json() == [
-        {
-            "can_create_groups": False,
-            "can_create_users": False,
-            "can_edit_roles": False,
-            "can_edit_settings": False,
-            "can_manage_infrastructure": False,
-            "can_triage_requests": False,
-            "can_upload_data": False,
-            "id": 1,
-            "name": "User",
-        },
-        {
-            "can_create_groups": True,
-            "can_create_users": True,
-            "can_edit_roles": False,
-            "can_edit_settings": True,
-            "can_manage_infrastructure": False,
-            "can_triage_requests": True,
-            "can_upload_data": True,
-            "id": 2,
-            "name": "Administrator",
-        },
-    ]
+    roles = result.get_json()
+    role1 = {
+        "can_create_groups": False,
+        "can_create_users": False,
+        "can_edit_roles": False,
+        "can_edit_settings": False,
+        "can_manage_infrastructure": False,
+        "can_triage_requests": False,
+        "can_upload_data": False,
+        "id": 1,
+        "name": "User",
+    }
+    role2 = {
+        "can_create_groups": True,
+        "can_create_users": True,
+        "can_edit_roles": False,
+        "can_edit_settings": True,
+        "can_manage_infrastructure": False,
+        "can_triage_requests": True,
+        "can_upload_data": True,
+        "id": 2,
+        "name": "Administrator",
+    }
+
+    assert role1.items() <= roles[0].items()
+    assert role2.items() <= roles[1].items()
 
 
 # GET SINGLE ROLE
@@ -421,7 +423,8 @@ def test_get_role_success(client, database, cleanup):
     result = client.get("/roles/1", headers=headers)
 
     assert result.status_code == 200
-    assert result.get_json() == {
+    role = result.get_json()
+    expected_role = {
         "id": 1,
         "name": "User",
         "can_triage_requests": False,
@@ -432,6 +435,8 @@ def test_get_role_success(client, database, cleanup):
         "can_manage_infrastructure": False,
         "can_upload_data": False,
     }
+
+    assert expected_role.items() <= role.items()
 
 
 # PUT ROLE

--- a/apps/domain/tests/test_routes/test_setup.py
+++ b/apps/domain/tests/test_routes/test_setup.py
@@ -105,7 +105,8 @@ def test_get_setup(client, database, cleanup):
     )
 
     assert result.status_code == 200
-    assert result.get_json() == {
+    setup = result.get_json()
+    expected_setup = {
         "id": 1,
         "domain_name": "OpenMined Domain",
         "private_key": "",
@@ -118,3 +119,4 @@ def test_get_setup(client, database, cleanup):
         "tensor_expiration_policy": 0,
         "allow_user_signup": False,
     }
+    assert expected_setup.items() <= setup.items()


### PR DESCRIPTION
## Description

Add a `created_at`, `updated_at`, and `deleted_at` key to models in the database. Make GET requests  default to not show rows with the `deleted_at` key set to anything except `Nil`.


closes #725


## How has this been tested?
- [ ] Add deletion related unit tests for each relevant route in Pygrid's Node / Domain
  + [x] Add DELETE related unit tests for each route in user API
  + [ ] Add DELETE related unit tests for each route in association API
  + [ ] Add DELETE related unit tests for each route in requests API
  + [ ] Add DELETE related unit tests for each route in roles API

- [ ] Add deletion related unit tests for each relevant route in Pygrid's Network

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
